### PR TITLE
chore(deps): remove dead deps react-leaflet + @vercel/node (apps/web)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -45,11 +45,9 @@
     "@tanstack/react-query": "^5.59.0",
     "@types/leaflet": "^1.9.20",
     "@upstash/redis": "^1.34.3",
-    "@vercel/node": "^2.3.0",
     "leaflet": "^1.9.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-leaflet": "^4.2.1",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@neondatabase/serverless": "^1.0.1",
         "@octokit/graphql": "^9.0.1",
         "@octokit/rest": "^22.0.0",
-        "@vercel/node": "^2.3.0",
         "cors": "^2.8.5",
         "dotenv": "^17.2.2",
         "express": "^5.1.0",
@@ -81,11 +80,9 @@
         "@tanstack/react-query": "^5.59.0",
         "@types/leaflet": "^1.9.20",
         "@upstash/redis": "^1.34.3",
-        "@vercel/node": "^2.3.0",
         "leaflet": "^1.9.4",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-leaflet": "^4.2.1",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -5690,17 +5687,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
-      }
-    },
-    "node_modules/@react-leaflet/core": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-2.1.0.tgz",
-      "integrity": "sha512-Qk7Pfu8BSarKGqILj4x7bCSZ1pjuAPZ+qmRwH5S7mDS91VSbVVsJSrW4qA+GPrro8t69gFYVMWb1Zc4yFmPiVg==",
-      "license": "Hippocratic-2.1",
-      "peerDependencies": {
-        "leaflet": "^1.9.0",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -18602,20 +18588,6 @@
       "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/react-leaflet": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-4.2.1.tgz",
-      "integrity": "sha512-p9chkvhcKrWn/H/1FFeVSqLdReGwn2qmiobOQGO3BifX+/vV/39qhY8dGqbdcPh1e6jxh/QHriLXr7a4eLFK4Q==",
-      "license": "Hippocratic-2.1",
-      "dependencies": {
-        "@react-leaflet/core": "^2.1.0"
-      },
-      "peerDependencies": {
-        "leaflet": "^1.9.0",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",

--- a/package.json
+++ b/package.json
@@ -177,7 +177,6 @@
     "@neondatabase/serverless": "^1.0.1",
     "@octokit/graphql": "^9.0.1",
     "@octokit/rest": "^22.0.0",
-    "@vercel/node": "^2.3.0",
     "cors": "^2.8.5",
     "dotenv": "^17.2.2",
     "express": "^5.1.0",


### PR DESCRIPTION
Replaces Dependabot PRs **#270** (`@vercel/node` 2→5) and **#246** (`react-leaflet` 4→5), which were both upgrades of **dead dependencies**.

### Findings (verified by code search)
- **`react-leaflet`** — imported nowhere; the map uses vanilla `leaflet` directly (`apps/web/src/components/MapContainer.tsx`). v5 also requires React 19 (repo pinned to React 18), so #246 was unmergeable.
- **`@vercel/node`** (apps/web + redundant root copy) — the deployed Vercel functions are plain `(req,res)` handlers importing nothing from it. Only `apps/api` uses its types and keeps its own declaration. v5 wouldn't have cleared the vulns (same vulnerable transitives).

### Effect
- **apps/web production-dependency vulns: 5 → 1** (both **HIGH** severity, via `@vercel/node` → `esbuild`/`path-to-regexp`, eliminated).
- Removes recurring Dependabot noise for two unused packages.
- Gate green: lint, type-check, build, **672** web tests.

Closes #270
Closes #246

Note: the non-deployed `apps/api` package still pulls `@vercel/node` (used for types), so the repo-root audit total is unchanged — a separate cleanup if `apps/api` is legacy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)