### PR TITLE
deps: upgrade zod 3→4 with v4 migration (closes #263)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -48,7 +48,7 @@
     "leaflet": "^1.9.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "zod": "^3.23.8"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@babel/preset-react": "^7.27.1",

--- a/apps/web/src/types/feedback.ts
+++ b/apps/web/src/types/feedback.ts
@@ -32,7 +32,7 @@ export interface FeedbackRecord {
 export const FeedbackSchema = z.object({
   rating: z.number().min(1).max(5),
   comment: z.string().min(1).max(1000),
-  email: z.string().email().optional().or(z.literal('')),
+  email: z.email().optional().or(z.literal('')),
   category: z.enum(['bug', 'feature', 'general']),
 })
 

--- a/apps/web/src/utils/validation.ts
+++ b/apps/web/src/utils/validation.ts
@@ -18,15 +18,10 @@ export const sanitizeHtml = (input: string): string => {
 // Validation schemas for different inputs
 export const UserInputSchemas = {
   weatherFilter: z.object({
-    temperature: z.enum(['warm', 'mild', 'cool'], {
-      errorMap: () => ({ message: 'Invalid temperature selection' })
-    }),
-    precipitation: z.enum(['none', 'light', 'any'], {
-      errorMap: () => ({ message: 'Invalid precipitation selection' })
-    }),
-    wind: z.enum(['calm', 'light', 'windy'], {
-      errorMap: () => ({ message: 'Invalid wind selection' })
-    }),
+    // zod v4: enum custom messages use `error` (replaced v3 `errorMap`)
+    temperature: z.enum(['warm', 'mild', 'cool'], { error: 'Invalid temperature selection' }),
+    precipitation: z.enum(['none', 'light', 'any'], { error: 'Invalid precipitation selection' }),
+    wind: z.enum(['calm', 'light', 'windy'], { error: 'Invalid wind selection' }),
   }),
 
   feedback: z.object({
@@ -34,14 +29,13 @@ export const UserInputSchemas = {
     comment: z.string()
       .max(1000, 'Comment must be less than 1000 characters')
       .transform(sanitizeString),
-    email: z.string()
-      .email('Invalid email format')
+    // zod v4: top-level z.email() (v3 .email() string method is deprecated and
+    // also dropped the custom message when wrapped in .or()); z.email keeps it.
+    email: z.email('Invalid email format')
       .max(254, 'Email is too long')
       .optional()
       .or(z.literal('')),
-    category: z.enum(['bug', 'feature', 'general'], {
-      errorMap: () => ({ message: 'Invalid feedback category' })
-    }),
+    category: z.enum(['bug', 'feature', 'general'], { error: 'Invalid feedback category' }),
   }),
 
   search: z.object({

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,7 @@
         "leaflet": "^1.9.4",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "zod": "^3.23.8"
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@babel/preset-react": "^7.27.1",
@@ -119,6 +119,15 @@
       "engines": {
         "node": ">=20.0.0",
         "npm": ">=10.8.0"
+      }
+    },
+    "apps/web/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -22860,6 +22869,7 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"


### PR DESCRIPTION
Supersedes Dependabot **#263** (`zod` 3.25.76 → 4.x), adding the code changes the bare bump needed to not break.

### Breaking changes migrated (only 2 affect our schemas)
- **`z.enum` custom messages**: v3 `{ errorMap: () => ({ message }) }` → v4 `{ error: '...' }` — `validation.ts` (weatherFilter temp/precip/wind + feedback category).
- **email in a union**: v3 `z.string().email(msg)` silently dropped the custom message when wrapped in `.optional().or(z.literal(''))`. Switched to v4 top-level **`z.email(msg)`**, which preserves it (verified empirically against zod 4.4.3). Applied in `validation.ts` and `types/feedback.ts`.

`weather.ts` enums (no custom messages) and all `z.infer` types are unaffected.

### Validation
- type-check ✅ · lint ✅ · build ✅
- **test:unit 172** ✅ · **validation suite 44** ✅ — no test changes needed (messages + union behavior preserved).

Closes #263

> Note: pre-existing `useLocalStorageState.test.ts` failures in the full apps/web vitest suite exist on `main` independent of this change (confirmed on clean `origin/main`); they aren't run by the CI gate and are unrelated to zod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)