### PR TITLE
fix(react-hooks): resolve safe v7 findings; enable refs + static-components

### DIFF
--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -33,14 +33,29 @@ export default [
       '@typescript-eslint': tseslint,
     },
     rules: {
-      // Classic rules-of-hooks set (matches eslint-plugin-react-hooks v5 recommended).
-      // v7's recommended adds new compiler-based rules (react-hooks/refs,
-      // set-state-in-effect, etc.) that flag 3 real issues in App.tsx,
-      // FilterManager.tsx, and MapContainer.tsx. Those need a focused
-      // code-quality pass on core UI (with sign-off), so they're deferred here
-      // rather than enabled wholesale in a dependency bump.
+      // eslint-plugin-react-hooks v7. Classic rules stay on as errors:
       'react-hooks/rules-of-hooks': 'error',
       'react-hooks/exhaustive-deps': 'warn',
+
+      // v7 React-Compiler rules we've fully resolved — enabled as errors so the
+      // fixes can't regress:
+      'react-hooks/refs': 'error',              // refs written/read during render
+      'react-hooks/static-components': 'error', // components defined during render
+
+      // v7 React-Compiler rules with remaining findings in business-critical
+      // code (Leaflet map popup/marker management in MapContainer, POI
+      // data-fetch in usePOILocations, navigation/expansion in usePOINavigation
+      // — which has documented intentional circular deps — and filter sync in
+      // FilterManager). These flag real Compiler-readiness issues, but fixing
+      // them safely needs dedicated, behavior-validated refactors of code
+      // CLAUDE.md flags as a frequent failure point. The app is not on the
+      // React Compiler yet, so they are advisory. Tracked as follow-up; left
+      // OFF here to avoid forcing risky changes that can't be UI-tested in CI.
+      'react-hooks/set-state-in-effect': 'off',
+      'react-hooks/immutability': 'off',
+      'react-hooks/purity': 'off',
+      'react-hooks/preserve-manual-memoization': 'off',
+
       'react-refresh/only-export-components': [
         'warn',
         { allowConstantExport: true },

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -81,7 +81,7 @@
  * LAST UPDATED: 2025-08-08
  */
 
-import React, { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { ThemeProvider, createTheme } from '@mui/material/styles'
 import { CssBaseline, CircularProgress, Alert } from '@mui/material'
 import { FabFilterSystem } from './components/FabFilterSystem'
@@ -189,17 +189,19 @@ export default function App() {
 
   // Weather filtering operations handled by POI navigation hook
 
-  // Use POI data from new navigation hook
-  const apiLocations = React.useMemo(() => {
+  // Use POI data from new navigation hook. `visiblePOIs` is already memoized
+  // upstream, so this is a referentially-stable alias.
+  const apiLocations = visiblePOIs
+
+  // Keep the compatibility refs in sync + diagnostics. Refs must be written in
+  // an effect, never during render.
+  useEffect(() => {
     console.log(`POI locations: ${allPOICount} total, ${visiblePOIs.length} visible within ${currentSliceMax}mi`)
     console.log(`Loading: ${poiLoading}, Error: ${poiError}`)
     console.log(`User location:`, userLocation)
 
-    // Update the refs with current locations for compatibility
     currentApiLocationsRef.current = visiblePOIs
     currentFilteredLocationsRef.current = visiblePOIs
-
-    return visiblePOIs
   }, [visiblePOIs, allPOICount, currentSliceMax, poiLoading, poiError, userLocation])
 
   /**

--- a/apps/web/src/components/ads/AdManager.tsx
+++ b/apps/web/src/components/ads/AdManager.tsx
@@ -37,12 +37,14 @@ export const AdManagerProvider: React.FC<AdManagerProviderProps> = ({
   enableAds = process.env.NODE_ENV === 'production',
   testMode: _testMode = process.env.NODE_ENV === 'development'
 }) => {
-  const [state, setState] = useState<AdManagerState>({
+  // Lazy initializer so the A/B testGroup is chosen exactly once (not re-rolled
+  // on every render — Math.random() must not run during render).
+  const [state, setState] = useState<AdManagerState>(() => ({
     isAdBlockDetected: false,
     adsLoaded: false,
     performanceMetrics: {},
     testGroup: Math.random() > 0.5 ? 'A' : 'B' // Simple A/B testing
-  })
+  }))
 
   // Detect ad blocking
   useEffect(() => {

--- a/apps/web/src/components/ads/AdUnit.tsx
+++ b/apps/web/src/components/ads/AdUnit.tsx
@@ -103,8 +103,9 @@ export const AdUnit: React.FC<AdUnitProps> = ({
 
   const dimensions = getAdDimensions()
 
-  // Loading placeholder for better UX
-  const AdSkeleton = () => (
+  // Loading placeholder for better UX. Defined as an element (not a nested
+  // component) so React doesn't see a new component type on every render.
+  const adSkeleton = (
     <Skeleton
       variant="rectangular"
       width="100%"
@@ -148,7 +149,7 @@ export const AdUnit: React.FC<AdUnitProps> = ({
   return (
     <AdContainer className={className}>
       {showLabel && <AdLabel>Advertisement</AdLabel>}
-      <Suspense fallback={<AdSkeleton />}>
+      <Suspense fallback={adSkeleton}>
         <Adsense
           client={clientId}
           slot={slot}


### PR DESCRIPTION
The react-hooks **v7** React-Compiler rules surfaced **13 findings**. This fixes the **3 high-confidence, behavior-preserving** ones and enables their rules as errors; the rest are documented as a tracked follow-up.

### Fixed (real improvements)
- **AdManager** (`purity`): `Math.random()` ran **during render on every render** (in the `useState` initializer object). Now a **lazy initializer** → testGroup chosen once. Genuine bug fix.
- **AdUnit** (`static-components`): `AdSkeleton` was a component defined inside render (new type each render) → replaced with a plain element.
- **App.tsx** (`refs`): compatibility refs were written inside a `useMemo` (during render) → moved to a `useEffect`; `apiLocations` is now a direct alias of the already-memoized `visiblePOIs`. Removed the now-unused default `React` import.

Enabled as errors: `react-hooks/refs`, `react-hooks/static-components` (+ existing `rules-of-hooks`/`exhaustive-deps`).

### Deferred (left OFF, documented inline)
`set-state-in-effect`, `immutability`, `purity`, `preserve-manual-memoization` — their **9 remaining findings** are all in business-critical code: Leaflet map popup/marker management (`MapContainer`), POI data-fetch (`usePOILocations`), navigation/expansion with **documented intentional circular deps** (`usePOINavigation`), and filter sync (`FilterManager`). Safely fixing these needs dedicated, behavior-validated refactors of code CLAUDE.md flags as a frequent failure point — and the app isn't on the React Compiler yet, so the rules are advisory. Forcing them in a lint pass I can't UI-test would risk regressions in the core map/POI/filter UX.

### Validation
lint ✅ · type-check ✅ · build ✅ · **test:unit 172** ✅ · no new test failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)