### PR TITLE
test: fix useLocalStorageState suite + exclude Playwright specs from vitest

### DIFF
--- a/apps/web/src/hooks/__tests__/useLocalStorageState.test.ts
+++ b/apps/web/src/hooks/__tests__/useLocalStorageState.test.ts
@@ -44,21 +44,23 @@ import { createLocalStorageMock } from '../../test/localStorage-setup'
 // Create isolated localStorage mock for this test file
 const localStorageMock = createLocalStorageMock()
 
-// Replace global localStorage with mock
-Object.defineProperty(global, 'localStorage', {
-  value: localStorageMock,
-  writable: true,
-  configurable: true
-})
+// Replace global localStorage with mock (merge with existing)
+if (typeof global.localStorage !== 'undefined') {
+  Object.defineProperty(global, 'localStorage', {
+    value: localStorageMock,
+    writable: true,
+    configurable: true
+  })
+}
 
-// Mock window object for SSR tests
-Object.defineProperty(global, 'window', {
-  value: {
-    localStorage: localStorageMock
-  },
-  writable: true,
-  configurable: true
-})
+// Mock window.localStorage for SSR tests (preserve existing window properties)
+if (typeof global.window !== 'undefined') {
+  Object.defineProperty(global.window, 'localStorage', {
+    value: localStorageMock,
+    writable: true,
+    configurable: true
+  })
+}
 
 describe('useLocalStorageState Hook', () => {
   beforeEach(() => {
@@ -68,6 +70,16 @@ describe('useLocalStorageState Hook', () => {
     Object.keys(localStorageMock.store).forEach(key => {
       delete localStorageMock.store[key]
     })
+
+    // Ensure window.event exists before each test (React-DOM requirement)
+    if (typeof global.window !== 'undefined' && !global.window.hasOwnProperty('event')) {
+      Object.defineProperty(global.window, 'event', {
+        get() {
+          return undefined
+        },
+        configurable: true
+      })
+    }
   })
 
   afterEach(() => {
@@ -252,18 +264,24 @@ describe('useLocalStorageState Hook', () => {
       expect(result.current[0]).toBe('updated')
     })
 
-    it('should handle server-side rendering (no window)', () => {
-      const originalWindow = global.window
-      // @ts-ignore
-      global.window = undefined
+    it('should handle server-side rendering (no localStorage)', () => {
+      // SSR environments have window but localStorage might be undefined or inaccessible
+      // Mock a more realistic SSR scenario
+      const originalGetItem = localStorageMock.getItem
+
+      localStorageMock.getItem.mockImplementation(() => {
+        throw new Error('localStorage is not available in SSR')
+      })
 
       const { result } = renderHook(() =>
         useLocalStorageState('ssrKey', 'default')
       )
 
+      // Should fall back to default value when localStorage is unavailable
       expect(result.current[0]).toBe('default')
 
-      global.window = originalWindow
+      // Restore localStorage
+      localStorageMock.getItem = originalGetItem
     })
   })
 

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -35,6 +35,41 @@ if (typeof global.Event === 'undefined') {
   }
 }
 
+// Fix for HTMLElement and activeElement required by React-DOM cleanup
+if (typeof global.HTMLElement === 'undefined') {
+  global.HTMLElement = class HTMLElement {} as any
+}
+
+// Ensure document.activeElement exists for React-DOM getActiveElementDeep
+if (typeof document !== 'undefined' && !document.activeElement) {
+  Object.defineProperty(document, 'activeElement', {
+    get() {
+      return null
+    },
+    configurable: true
+  })
+}
+
+// Ensure window.event exists for React-DOM getCurrentEventPriority
+if (typeof window !== 'undefined' && !window.hasOwnProperty('event')) {
+  Object.defineProperty(window, 'event', {
+    get() {
+      return undefined
+    },
+    configurable: true
+  })
+}
+
+// Also ensure it exists on global.window
+if (typeof global.window !== 'undefined' && !global.window.hasOwnProperty('event')) {
+  Object.defineProperty(global.window, 'event', {
+    get() {
+      return undefined
+    },
+    configurable: true
+  })
+}
+
 // Establish API mocking before all tests
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
 

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -13,6 +13,15 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],
     css: true,
+    // Exclude Playwright E2E tests from Vitest
+    exclude: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/*.spec.js',  // Playwright E2E tests
+      '**/*.spec.ts',  // Playwright E2E tests
+      '**/tests/e2e/**',
+      '**/tests/**/*.spec.{js,ts}',  // Any spec files in tests directory
+    ],
     // Disable parallel execution for hook tests to prevent environment conflicts
     threads: false,
     pool: 'forks',


### PR DESCRIPTION
Completes the in-flight test-infra work. Takes the **apps/web vitest suite from 35 failing to fully green (24 files, 672/672)**.

- **`src/test/setup.ts`** — add jsdom polyfills React-DOM's cleanup path needs (`HTMLElement`, `document.activeElement`, `window.event`); their absence threw during render/cleanup and failed the hook tests.
- **`useLocalStorageState.test.ts`** — stop clobbering the jsdom `window`: merge the localStorage mock into the existing global/window instead of replacing `window` wholesale (which broke React-DOM). Rewrite the SSR test to simulate localStorage being unavailable (throwing `getItem`) rather than deleting `global.window`.
- **`vitest.config.ts`** — exclude Playwright `*.spec.{js,ts}`/e2e files so vitest stops collecting them (`poi-popup-visual.spec.js` was erroring).

(The unrelated `public/health.json` runtime-timestamp change from the working tree was intentionally left out.)

### Validation
lint ✅ · type-check ✅ · build ✅ · **test:unit 172** ✅ · **full apps/web suite 672/672** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)