### PR TITLE
refactor: extract MapContainer popup builders into pure tested module (#4)

### DIFF
--- a/apps/web/src/components/MapContainer.tsx
+++ b/apps/web/src/components/MapContainer.tsx
@@ -52,9 +52,8 @@
 
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import L from 'leaflet';
-import { escapeHtml, sanitizeUrl } from '../utils/sanitize';
-import { generateMediaNetPopupAdHTML } from '../utils/adUtils';
 import { trackPOIInteraction, trackFeatureUsage } from '../utils/analytics';
+import { buildPoiPopupHtml } from '../utils/mapPopup';
 // Import POI popup styles
 import '../styles/poi-popup.css';
 
@@ -323,119 +322,20 @@ export const MapContainer: React.FC<MapContainerProps> = ({
     userMarkerRef.current.setLatLng(userLocation);
   }, [userLocation]);
 
-  // Helper function to detect platform and generate appropriate mapping URL
-  const generateMappingUrl = useCallback((location: POILocation): string => {
-    const coords = `${location.lat},${location.lng}`;
-    const locationName = encodeURIComponent(location.name);
-
-    // Detect platform based on user agent
-    const userAgent = navigator.userAgent || '';
-    const isIOS = /iPad|iPhone|iPod/.test(userAgent);
-    const isAndroid = /Android/.test(userAgent);
-    const isMobile = /Mobi|Android/i.test(userAgent);
-
-    // Platform-specific URL generation
-    if (isIOS) {
-      // iOS: Use Apple Maps
-      return `http://maps.apple.com/?daddr=${coords}&dirflg=d`;
-    } else if (isAndroid) {
-      // Android: Use geo: URL for Google Maps
-      return `geo:${coords}?q=${coords}(${locationName})`;
-    } else if (isMobile) {
-      // Other mobile: Try geo: first
-      return `geo:${coords}?q=${coords}(${locationName})`;
-    } else {
-      // Desktop: Use Google Maps web interface
-      return `https://www.google.com/maps/dir/?api=1&destination=${coords}`;
-    }
-  }, []);
-
-  // Helper function to create popup content
+  // Popup HTML + mapping-URL logic lives in ../utils/mapPopup (pure + tested).
+  // This thin wrapper supplies the current navigation state.
   const createPopupContent = useCallback((location: POILocation): string => {
-    // Sanitize all user content
-    const safeName = escapeHtml(location.name);
-    const safeParkType = location.park_type ? escapeHtml(location.park_type) : '';
-    const safeDescription = escapeHtml(location.description);
-    const safeCondition = escapeHtml(location.condition);
-    const safeWindSpeed = escapeHtml(location.windSpeed);
-    const safeWeatherStation = location.weather_station_name ? escapeHtml(location.weather_station_name) : '';
-    const safeWeatherDistance = location.weather_distance_miles ? escapeHtml(location.weather_distance_miles) : '';
-
-    // Generate platform-appropriate mapping URL
-    const mapsUrl = sanitizeUrl(generateMappingUrl(location));
-
-    // Generate Media.net contextual ad content for geographic optimization
-    // Convert MapContainer POILocation to adUtils POILocation format
-    const adUtilsLocation = {
-      id: location.id,
-      name: location.name,
-      temperature: location.temperature,
-      precipitation: location.precipitation,
-      latitude: location.lat,
-      longitude: location.lng,
-      park_type: (location as any).park_type // Optional field
-    };
-    const contextualAdHTML = generateMediaNetPopupAdHTML(adUtilsLocation, process.env.NODE_ENV === 'development');
-
-    return `
-      <div class="poi-popup-container">
-        <div class="mb-2">
-          <!-- Title row with directions button -->
-          <div class="poi-title-row">
-            <a href="${mapsUrl}"
-               target="_blank" rel="noopener noreferrer"
-               title="Get directions"
-               class="poi-directions-button"
-               data-analytics-poi="${safeName}"
-               data-analytics-action="directions-clicked">
-              🧭
-            </a>
-            <h3 class="poi-title">${safeName}</h3>
-          </div>
-
-          ${safeParkType ? `<div class="poi-park-type">${safeParkType}</div>` : ''}
-
-          <!-- Full width description -->
-          <p class="poi-description">${safeDescription}</p>
-
-          <!-- Full width contextual Ad Container -->
-          ${contextualAdHTML}
-        </div>
-
-        <!-- Weather Information -->
-        <div class="bg-gray-100 rounded p-2 mb-2 border">
-          <div class="flex justify-between items-center text-xs text-black font-medium" style="gap: 5px">
-            <span class="font-bold text-lg text-black">${escapeHtml(location.temperature)}°F</span>
-            <span class="text-lg">
-              ${safeCondition === 'Sunny' ? '☀️' :
-                safeCondition === 'Partly Cloudy' ? '⛅' :
-                safeCondition === 'Cloudy' ? '☁️' :
-                safeCondition === 'Overcast' ? '🌫️' :
-                safeCondition === 'Clear' ? '✨' : safeCondition}
-            </span>
-            <span>💧 ${escapeHtml(location.precipitation)}%</span>
-            <span>💨 ${safeWindSpeed}</span>
-          </div>
-          ${safeWeatherStation ? `<div class="text-xs text-gray-600 mt-1">Weather from ${safeWeatherStation}${safeWeatherDistance ? ` (${safeWeatherDistance} mi)` : ''}</div>` : ''}
-        </div>
-
-        <!-- Navigation Controls -->
-        ${(locations.length > 1 || canExpand) ? `
-        <div class="poi-nav-container" data-popup-nav="true">
-          <button data-nav-action="closer"
-                  ${isAtClosest ? 'disabled' : ''}
-                  class="poi-nav-button ${isAtClosest ? '' : ''}">
-            ← Closer
-          </button>
-          <button data-nav-action="farther"
-                  class="poi-nav-button ${isAtFarthest && !canExpand ? 'farther-disabled' : ''}">
-            ${canExpand && isAtFarthest ? '🔍 Expand +30mi' : isAtFarthest && !canExpand ? 'No More →' : 'Farther →'}
-          </button>
-        </div>
-        ` : ''}
-      </div>
-    `;
-  }, [isAtClosest, isAtFarthest, canExpand, locations.length, generateMappingUrl]);
+    return buildPoiPopupHtml(
+      location,
+      {
+        hasNavigation: locations.length > 1 || canExpand,
+        isAtClosest,
+        isAtFarthest,
+        canExpand,
+      },
+      process.env.NODE_ENV === 'development'
+    );
+  }, [isAtClosest, isAtFarthest, canExpand, locations.length]);
 
   // Function to update popup content with current navigation state
   const updatePopupContent = useCallback((markerIndex: number) => {

--- a/apps/web/src/utils/__tests__/mapPopup.test.ts
+++ b/apps/web/src/utils/__tests__/mapPopup.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for the extracted map-popup builders (pure, from MapContainer).
+ * Covers HTML sanitization, conditional sections, navigation-control states,
+ * and platform-specific mapping-URL generation.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { buildPoiPopupHtml, generateMappingUrl, type PopupLocation, type PopupNavState } from '../mapPopup'
+
+const baseLoc: PopupLocation = {
+  id: '1',
+  name: 'Theodore Wirth Park',
+  lat: 44.98,
+  lng: -93.31,
+  temperature: 72,
+  condition: 'Sunny',
+  description: 'A large urban park.',
+  precipitation: 10,
+  windSpeed: '5 mph',
+}
+
+const noNav: PopupNavState = {
+  hasNavigation: false,
+  isAtClosest: false,
+  isAtFarthest: false,
+  canExpand: false,
+}
+
+describe('buildPoiPopupHtml', () => {
+  it('renders the POI name, temperature, precipitation, and wind', () => {
+    const html = buildPoiPopupHtml(baseLoc, noNav, false)
+    expect(html).toContain('Theodore Wirth Park')
+    expect(html).toContain('72°F')
+    expect(html).toContain('10%')
+    expect(html).toContain('5 mph')
+  })
+
+  it('maps known conditions to emoji', () => {
+    expect(buildPoiPopupHtml({ ...baseLoc, condition: 'Sunny' }, noNav, false)).toContain('☀️')
+    expect(buildPoiPopupHtml({ ...baseLoc, condition: 'Partly Cloudy' }, noNav, false)).toContain('⛅')
+    expect(buildPoiPopupHtml({ ...baseLoc, condition: 'Clear' }, noNav, false)).toContain('✨')
+  })
+
+  it('falls back to the raw condition text for unknown conditions', () => {
+    const html = buildPoiPopupHtml({ ...baseLoc, condition: 'Drizzle' }, noNav, false)
+    expect(html).toContain('Drizzle')
+  })
+
+  it('escapes HTML in the fields it renders (title + description)', () => {
+    const html = buildPoiPopupHtml(
+      { ...baseLoc, name: '<img src=x onerror=alert(1)>', description: '<b>bold</b>' },
+      noNav,
+      false
+    )
+    // The popup title and description must be HTML-escaped.
+    expect(html).toContain('&lt;img src=x onerror=alert(1)&gt;') // title escaped
+    expect(html).toContain('&lt;b&gt;bold&lt;/b&gt;') // description escaped
+    // The poi-title block specifically must not carry a raw tag.
+    const titleBlock = html.slice(html.indexOf('poi-title">'), html.indexOf('poi-title">') + 60)
+    expect(titleBlock).not.toContain('<img')
+    // NOTE: the embedded contextual-ad HTML (generateMediaNetPopupAdHTML) is a
+    // separate concern and currently interpolates the RAW name into an inline
+    // <script> — a pre-existing injection vector tracked outside this module.
+  })
+
+  it('omits the park-type block when park_type is absent', () => {
+    const html = buildPoiPopupHtml(baseLoc, noNav, false)
+    expect(html).not.toContain('poi-park-type')
+  })
+
+  it('includes the park-type block when present', () => {
+    const html = buildPoiPopupHtml({ ...baseLoc, park_type: 'State Park' }, noNav, false)
+    expect(html).toContain('poi-park-type')
+    expect(html).toContain('State Park')
+  })
+
+  it('shows weather-station attribution only when provided', () => {
+    expect(buildPoiPopupHtml(baseLoc, noNav, false)).not.toContain('Weather from')
+    const withStation = buildPoiPopupHtml(
+      { ...baseLoc, weather_station_name: 'KMSP', weather_distance_miles: '3.2' },
+      noNav,
+      false
+    )
+    expect(withStation).toContain('Weather from KMSP')
+    expect(withStation).toContain('(3.2 mi)')
+  })
+
+  describe('navigation controls', () => {
+    it('omits nav controls when hasNavigation is false', () => {
+      expect(buildPoiPopupHtml(baseLoc, noNav, false)).not.toContain('data-popup-nav')
+    })
+
+    it('renders Closer/Farther when hasNavigation is true', () => {
+      const html = buildPoiPopupHtml(baseLoc, { ...noNav, hasNavigation: true }, false)
+      expect(html).toContain('data-popup-nav="true"')
+      expect(html).toContain('data-nav-action="closer"')
+      expect(html).toContain('data-nav-action="farther"')
+      expect(html).toContain('Farther →')
+    })
+
+    it('disables Closer at the closest POI', () => {
+      const html = buildPoiPopupHtml(baseLoc, { ...noNav, hasNavigation: true, isAtClosest: true }, false)
+      expect(html).toMatch(/data-nav-action="closer"\s+disabled/)
+    })
+
+    it('shows the expand affordance at the farthest POI when expandable', () => {
+      const html = buildPoiPopupHtml(
+        baseLoc,
+        { hasNavigation: true, isAtClosest: false, isAtFarthest: true, canExpand: true },
+        false
+      )
+      expect(html).toContain('🔍 Expand +30mi')
+    })
+
+    it('shows "No More" at the farthest POI when not expandable', () => {
+      const html = buildPoiPopupHtml(
+        baseLoc,
+        { hasNavigation: true, isAtClosest: false, isAtFarthest: true, canExpand: false },
+        false
+      )
+      expect(html).toContain('No More →')
+      expect(html).toContain('farther-disabled')
+    })
+  })
+})
+
+describe('generateMappingUrl', () => {
+  const origUA = Object.getOwnPropertyDescriptor(window.navigator, 'userAgent')
+  const setUA = (ua: string) =>
+    Object.defineProperty(window.navigator, 'userAgent', { value: ua, configurable: true })
+
+  afterEach(() => {
+    if (origUA) Object.defineProperty(window.navigator, 'userAgent', origUA)
+  })
+
+  const loc = { lat: 44.98, lng: -93.31, name: 'Wirth Park' }
+
+  it('uses Apple Maps on iOS', () => {
+    setUA('Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)')
+    expect(generateMappingUrl(loc)).toBe('http://maps.apple.com/?daddr=44.98,-93.31&dirflg=d')
+  })
+
+  it('uses a geo: URL on Android', () => {
+    setUA('Mozilla/5.0 (Linux; Android 14)')
+    expect(generateMappingUrl(loc)).toBe('geo:44.98,-93.31?q=44.98,-93.31(Wirth%20Park)')
+  })
+
+  it('uses Google Maps web on desktop', () => {
+    setUA('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)')
+    expect(generateMappingUrl(loc)).toBe('https://www.google.com/maps/dir/?api=1&destination=44.98,-93.31')
+  })
+
+  it('url-encodes the location name for mobile geo URLs', () => {
+    setUA('Mozilla/5.0 (Linux; Android 14)')
+    const url = generateMappingUrl({ ...loc, name: 'Lake Harriet & Bandshell' })
+    expect(url).toContain('Lake%20Harriet%20%26%20Bandshell')
+  })
+})

--- a/apps/web/src/utils/mapPopup.ts
+++ b/apps/web/src/utils/mapPopup.ts
@@ -1,0 +1,177 @@
+/**
+ * ========================================================================
+ * MAP POPUP CONTENT BUILDERS
+ * ========================================================================
+ *
+ * Pure helpers for the Leaflet POI popups, extracted from MapContainer.tsx
+ * so the (XSS-sanitized) HTML generation and platform mapping-URL logic are
+ * unit-testable and the component stays focused on imperative map wiring.
+ *
+ * All user-supplied fields are escaped via escapeHtml; the directions URL is
+ * passed through sanitizeUrl. These functions are deterministic given their
+ * inputs (generateMappingUrl additionally reads navigator.userAgent).
+ *
+ * @CLAUDE_CONTEXT: Extracted from MapContainer.tsx for testability + size.
+ * ========================================================================
+ */
+
+import { escapeHtml, sanitizeUrl } from './sanitize'
+import { generateMediaNetPopupAdHTML } from './adUtils'
+
+/** Subset of the POI shape the popup needs. */
+export interface PopupLocation {
+  id: string
+  name: string
+  lat: number
+  lng: number
+  temperature: number
+  condition: string
+  description: string
+  precipitation: number
+  windSpeed: string
+  park_type?: string
+  weather_station_name?: string
+  weather_distance_miles?: string
+}
+
+/** Navigation-control state that drives the popup's Closer/Farther buttons. */
+export interface PopupNavState {
+  /** Whether to render the navigation controls at all (multiple POIs or expandable). */
+  hasNavigation: boolean
+  isAtClosest: boolean
+  isAtFarthest: boolean
+  canExpand: boolean
+}
+
+/**
+ * Build a platform-appropriate mapping/directions URL for a location.
+ * iOS → Apple Maps, Android/other-mobile → geo: URL, desktop → Google Maps web.
+ */
+export function generateMappingUrl(location: Pick<PopupLocation, 'lat' | 'lng' | 'name'>): string {
+  const coords = `${location.lat},${location.lng}`
+  const locationName = encodeURIComponent(location.name)
+
+  const userAgent = (typeof navigator !== 'undefined' && navigator.userAgent) || ''
+  const isIOS = /iPad|iPhone|iPod/.test(userAgent)
+  const isAndroid = /Android/.test(userAgent)
+  const isMobile = /Mobi|Android/i.test(userAgent)
+
+  if (isIOS) {
+    return `http://maps.apple.com/?daddr=${coords}&dirflg=d`
+  } else if (isAndroid) {
+    return `geo:${coords}?q=${coords}(${locationName})`
+  } else if (isMobile) {
+    return `geo:${coords}?q=${coords}(${locationName})`
+  } else {
+    return `https://www.google.com/maps/dir/?api=1&destination=${coords}`
+  }
+}
+
+/** Map an OpenWeather-style condition string to a display emoji. */
+function conditionEmoji(condition: string): string {
+  switch (condition) {
+    case 'Sunny':
+      return '☀️'
+    case 'Partly Cloudy':
+      return '⛅'
+    case 'Cloudy':
+      return '☁️'
+    case 'Overcast':
+      return '🌫️'
+    case 'Clear':
+      return '✨'
+    default:
+      return condition
+  }
+}
+
+/**
+ * Build the sanitized HTML string for a POI marker popup.
+ *
+ * @param location POI to render
+ * @param nav navigation-control state
+ * @param isDev passed to the contextual-ad generator (test-mode placeholder)
+ */
+export function buildPoiPopupHtml(
+  location: PopupLocation,
+  nav: PopupNavState,
+  isDev: boolean
+): string {
+  // Sanitize all user content
+  const safeName = escapeHtml(location.name)
+  const safeParkType = location.park_type ? escapeHtml(location.park_type) : ''
+  const safeDescription = escapeHtml(location.description)
+  const safeCondition = escapeHtml(location.condition)
+  const safeWindSpeed = escapeHtml(location.windSpeed)
+  const safeWeatherStation = location.weather_station_name ? escapeHtml(location.weather_station_name) : ''
+  const safeWeatherDistance = location.weather_distance_miles ? escapeHtml(location.weather_distance_miles) : ''
+
+  const mapsUrl = sanitizeUrl(generateMappingUrl(location))
+
+  // Contextual ad content (adUtils uses latitude/longitude field names)
+  const adUtilsLocation = {
+    id: location.id,
+    name: location.name,
+    temperature: location.temperature,
+    precipitation: location.precipitation,
+    latitude: location.lat,
+    longitude: location.lng,
+    park_type: location.park_type,
+  }
+  const contextualAdHTML = generateMediaNetPopupAdHTML(adUtilsLocation, isDev)
+
+  return `
+      <div class="poi-popup-container">
+        <div class="mb-2">
+          <!-- Title row with directions button -->
+          <div class="poi-title-row">
+            <a href="${mapsUrl}"
+               target="_blank" rel="noopener noreferrer"
+               title="Get directions"
+               class="poi-directions-button"
+               data-analytics-poi="${safeName}"
+               data-analytics-action="directions-clicked">
+              🧭
+            </a>
+            <h3 class="poi-title">${safeName}</h3>
+          </div>
+
+          ${safeParkType ? `<div class="poi-park-type">${safeParkType}</div>` : ''}
+
+          <!-- Full width description -->
+          <p class="poi-description">${safeDescription}</p>
+
+          <!-- Full width contextual Ad Container -->
+          ${contextualAdHTML}
+        </div>
+
+        <!-- Weather Information -->
+        <div class="bg-gray-100 rounded p-2 mb-2 border">
+          <div class="flex justify-between items-center text-xs text-black font-medium" style="gap: 5px">
+            <span class="font-bold text-lg text-black">${escapeHtml(location.temperature)}°F</span>
+            <span class="text-lg">
+              ${conditionEmoji(safeCondition)}
+            </span>
+            <span>💧 ${escapeHtml(location.precipitation)}%</span>
+            <span>💨 ${safeWindSpeed}</span>
+          </div>
+          ${safeWeatherStation ? `<div class="text-xs text-gray-600 mt-1">Weather from ${safeWeatherStation}${safeWeatherDistance ? ` (${safeWeatherDistance} mi)` : ''}</div>` : ''}
+        </div>
+
+        <!-- Navigation Controls -->
+        ${nav.hasNavigation ? `
+        <div class="poi-nav-container" data-popup-nav="true">
+          <button data-nav-action="closer"
+                  ${nav.isAtClosest ? 'disabled' : ''}
+                  class="poi-nav-button ${nav.isAtClosest ? '' : ''}">
+            ← Closer
+          </button>
+          <button data-nav-action="farther"
+                  class="poi-nav-button ${nav.isAtFarthest && !nav.canExpand ? 'farther-disabled' : ''}">
+            ${nav.canExpand && nav.isAtFarthest ? '🔍 Expand +30mi' : nav.isAtFarthest && !nav.canExpand ? 'No More →' : 'Farther →'}
+          </button>
+        </div>
+        ` : ''}
+      </div>
+    `
+}

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -60,10 +60,10 @@ export default defineConfig({
       // tests are added (do not lower). NB: vitest 4 dropped the `global` nesting
       // — thresholds live directly under `thresholds`.
       thresholds: {
-        branches: 29,
-        functions: 38,
-        lines: 31,
-        statements: 31
+        branches: 33,
+        functions: 39,
+        lines: 33,
+        statements: 33
       }
     },
     // Watch mode configuration


### PR DESCRIPTION
Progress on **#4** (decompose the >600 LOC files). Pulls the POI popup HTML builder + platform mapping-URL logic out of `MapContainer.tsx` into a pure, tested module — **behavior-preserving**.

### Changes
- **`MapContainer.tsx`: 613 → 513 LOC.** `createPopupContent` is now a thin `useCallback` that passes nav-state into `buildPoiPopupHtml`; the inline `generateMappingUrl` + ~85-line HTML template are gone.
- **`src/utils/mapPopup.ts`** (new): `buildPoiPopupHtml` (sanitized popup HTML) + `generateMappingUrl` (iOS/Android/desktop), both pure.
- **`mapPopup.test.ts`** (new): 16 tests — field rendering, HTML escaping of title/description, conditional sections (park type, weather station), all nav-control states, and platform URL branches.

### Result
- Whole-codebase coverage **32.3% → 33.8%**; tests **702 → 718**; thresholds ratcheted up.
- lint ✅ · type-check ✅ · build ✅

### ⚠️ Security finding surfaced (pre-existing, NOT changed here)
While extracting, I confirmed `generateMediaNetPopupAdHTML` (`adUtils.ts:39`) interpolates the **raw POI `name` into an inline `<script>`** — a script-injection vector if a POI name contains `</script>` or a quote (POI names originate from OSM/DB data). This PR **preserves** the existing behavior (the old MapContainer passed the raw name too); the fix belongs in `adUtils` and needs JS-string escaping. **Recommend a follow-up.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)