### PR TITLE
fix(security): prevent script injection via POI fields in contextual ads

### DIFF
--- a/apps/web/src/utils/__tests__/adUtils.test.ts
+++ b/apps/web/src/utils/__tests__/adUtils.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for contextual-ad HTML generation, focused on the inline-<script>
+ * injection fix: attacker-controlled POI fields must not be able to break out
+ * of the script block or inject live HTML.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { generateMediaNetPopupAdHTML, generatePOIAdHTML, type POILocation } from '../adUtils'
+
+const base: POILocation = {
+  id: '386',
+  name: 'Theodore Wirth Park',
+  temperature: 72,
+  precipitation: 10,
+  park_type: 'Regional Park',
+  latitude: 44.98,
+  longitude: -93.31,
+}
+
+// A name engineered to break out of an inline <script> and inject live HTML.
+const MALICIOUS = `</script><img src=x onerror=alert(document.cookie)>`
+
+describe('generateMediaNetPopupAdHTML', () => {
+  it('produces an ad container with an inline script for normal input', () => {
+    const html = generateMediaNetPopupAdHTML(base, false)
+    expect(html).toContain('medianet-popup-ad-386')
+    expect(html).toContain('window.mnet')
+    expect(html).toContain('Theodore Wirth Park, Minnesota')
+  })
+
+  it('does NOT allow a malicious name to break out of the <script>', () => {
+    const html = generateMediaNetPopupAdHTML({ ...base, name: MALICIOUS }, false)
+    // The literal </script> + <img> breakout must not appear in the output.
+    expect(html).not.toContain('</script><img')
+    expect(html).not.toContain('<img src=x onerror=')
+    // There must be exactly one real closing </script> tag (the legit one).
+    expect(html.match(/<\/script>/g) ?? []).toHaveLength(1)
+    // The payload survives only as an escaped JS-string value.
+    expect(html).toContain('\\u003c/script\\u003e')
+  })
+
+  it('escapes a malicious id used in the container attribute', () => {
+    const html = generateMediaNetPopupAdHTML({ ...base, id: '"><img src=x onerror=alert(1)>' }, false)
+    expect(html).not.toContain('"><img')
+    expect(html).toContain('&quot;&gt;&lt;img')
+  })
+
+  it('escapes keywords in test-mode HTML output', () => {
+    const html = generateMediaNetPopupAdHTML({ ...base, park_type: '<b>x</b>' }, true)
+    // testMode renders keywords into HTML text — must be escaped (park_type only
+    // affects the derived keyword, but ensure no raw tags leak regardless).
+    expect(html).not.toContain('<b>x</b>')
+  })
+
+  it('serializes coordinates as a numeric array', () => {
+    const html = generateMediaNetPopupAdHTML(base, false)
+    expect(html).toContain('"coordinates":[44.98,-93.31]')
+  })
+})
+
+describe('generatePOIAdHTML', () => {
+  it('produces a contextual ad container for normal input', () => {
+    const html = generatePOIAdHTML(base, false)
+    expect(html).toContain('contextual-poi-ad-386')
+    expect(html).toContain('window.contextualAds')
+    expect(html).toContain('Theodore Wirth Park')
+  })
+
+  it('does NOT allow a malicious name to break out of the <script>', () => {
+    const html = generatePOIAdHTML({ ...base, name: MALICIOUS }, false)
+    expect(html).not.toContain('</script><img')
+    expect(html).not.toContain('<img src=x onerror=')
+    expect(html.match(/<\/script>/g) ?? []).toHaveLength(1)
+  })
+
+  it('preserves a temperature of 0 (uses nullish coalescing, not ||)', () => {
+    const html = generatePOIAdHTML({ ...base, temperature: 0 }, false)
+    expect(html).toContain('"temperature":0')
+  })
+
+  it('escapes user content in test-mode HTML', () => {
+    const html = generatePOIAdHTML({ ...base, name: '<script>alert(1)</script>' }, true)
+    expect(html).not.toContain('<script>alert(1)</script>')
+  })
+})

--- a/apps/web/src/utils/adUtils.ts
+++ b/apps/web/src/utils/adUtils.ts
@@ -12,6 +12,35 @@ export interface POILocation {
 }
 
 /**
+ * Serialize a value for safe embedding inside an inline <script> block.
+ *
+ * JSON.stringify escapes quotes/backslashes; the unicode replacements prevent
+ * a `</script>` (or `<!--`) sequence in the data from breaking out of the
+ * script element — which would otherwise allow injecting live HTML (e.g.
+ * `</script><img src=x onerror=...>`) even when the surrounding markup is set
+ * via innerHTML.  /  are escaped because they are valid JSON but
+ * illegal raw in a JS string literal.
+ */
+function toScriptJson(value: unknown): string {
+  return JSON.stringify(value ?? null)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026')
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}
+
+/** Escape a value for an HTML attribute or text context. */
+function escapeHtmlAttr(value: unknown): string {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
  * Generate Media.net contextual ad HTML for map popup integration
  * Optimized for geographic constraint context and weather awareness
  */
@@ -26,21 +55,25 @@ export const generateMediaNetPopupAdHTML = (location: POILocation, testMode: boo
   if (testMode) {
     return `<div style="background: #f0f8ff; padding: 8px; border-radius: 4px; font-size: 12px;">
       <strong>Media.net Test Ad</strong><br/>
-      Context: ${contextualKeywords}<br/>
+      Context: ${escapeHtmlAttr(contextualKeywords)}<br/>
       <em>Real ads will appear here in production</em>
     </div>`;
   }
 
-  return `<div id="medianet-popup-ad-${location.id}" style="margin: 8px 0;">
+  // All dynamic data is embedded via toScriptJson so an attacker-controlled POI
+  // name cannot break out of the inline <script>.
+  const safeId = escapeHtmlAttr(location.id);
+  const contextual = {
+    targeting: contextualKeywords,
+    location: `${location.name}, Minnesota`,
+    coordinates: [location.latitude, location.longitude],
+  };
+  return `<div id="medianet-popup-ad-${safeId}" style="margin: 8px 0;">
     <script>
       (function() {
-        var contextual = {
-          targeting: '${contextualKeywords}',
-          location: '${location.name}, Minnesota',
-          coordinates: [${location.latitude}, ${location.longitude}]
-        };
+        var contextual = ${toScriptJson(contextual)};
         if (window.mnet) {
-          window.mnet.loadAd('popup-ad-${location.id}', contextual);
+          window.mnet.loadAd(${toScriptJson(`popup-ad-${location.id}`)}, contextual);
         }
       })();
     </script>
@@ -66,28 +99,32 @@ export const generatePOIAdHTML = (location: POILocation, testMode: boolean = fal
   if (testMode) {
     return `<div style="background: linear-gradient(135deg, #e3f2fd, #fff3e0); padding: 12px; border-radius: 8px; margin: 10px 0;">
       <div style="font-weight: bold; color: #1976d2; margin-bottom: 4px;">🎯 Contextual Test Ad</div>
-      <div style="font-size: 11px; color: #666;">Keywords: ${activityKeywords}</div>
-      <div style="font-size: 11px; color: #666;">Weather: ${location.temperature}°F, ${location.precipitation}% chance rain</div>
+      <div style="font-size: 11px; color: #666;">Keywords: ${escapeHtmlAttr(activityKeywords)}</div>
+      <div style="font-size: 11px; color: #666;">Weather: ${escapeHtmlAttr(location.temperature)}°F, ${escapeHtmlAttr(location.precipitation)}% chance rain</div>
       <div style="font-style: italic; color: #999; margin-top: 6px;">Production ads will be geo-targeted and weather-aware</div>
     </div>`;
   }
 
-  return `<div id="contextual-poi-ad-${location.id}" class="poi-contextual-ad" style="margin: 10px 0;">
+  // Embed the config via toScriptJson to neutralize injection through the POI
+  // name / keywords inside the inline <script>.
+  const safeId = escapeHtmlAttr(location.id);
+  const adConfig = {
+    containerId: `contextual-poi-ad-${location.id}`,
+    keywords: activityKeywords,
+    location: {
+      name: location.name,
+      coordinates: [location.latitude, location.longitude],
+      weather: {
+        temperature: location.temperature ?? null,
+        precipitation: location.precipitation ?? null,
+      },
+    },
+  };
+  return `<div id="contextual-poi-ad-${safeId}" class="poi-contextual-ad" style="margin: 10px 0;">
     <script>
       (function() {
         if (window.contextualAds) {
-          window.contextualAds.display({
-            containerId: 'contextual-poi-ad-${location.id}',
-            keywords: '${activityKeywords}',
-            location: {
-              name: '${location.name}',
-              coordinates: [${location.latitude}, ${location.longitude}],
-              weather: {
-                temperature: ${location.temperature || 'null'},
-                precipitation: ${location.precipitation || 'null'}
-              }
-            }
-          });
+          window.contextualAds.display(${toScriptJson(adConfig)});
         }
       })();
     </script>

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -60,10 +60,10 @@ export default defineConfig({
       // tests are added (do not lower). NB: vitest 4 dropped the `global` nesting
       // — thresholds live directly under `thresholds`.
       thresholds: {
-        branches: 33,
-        functions: 39,
-        lines: 33,
-        statements: 33
+        branches: 34,
+        functions: 40,
+        lines: 34,
+        statements: 34
       }
     },
     // Watch mode configuration


### PR DESCRIPTION
Fixes the inline-`<script>` injection surfaced during the MapContainer decomposition (#305).

### The vulnerability
`generateMediaNetPopupAdHTML` and `generatePOIAdHTML` (`adUtils.ts`) interpolated untrusted POI fields — **`name`, `id`, derived keywords** — directly into inline `<script>` string literals:
```js
location: '${location.name}, Minnesota',
```
A POI name like `</script><img src=x onerror=alert(document.cookie)>` breaks out of the `<script>` and injects a live element — **exploitable even though Leaflet sets popup markup via `innerHTML`** (the injected `<img onerror>` still fires). POI names come from OSM/DB data. (CWE-79 / CWE-94)

### The fix
- **`toScriptJson()`** — embed all dynamic data as JSON with `</script>`-breakout protection (escape `<` `>` `&` and U+2028/U+2029). Replaces the hand-built single-quoted JS-string interpolation in both functions.
- **`escapeHtmlAttr()`** — escape the POI `id` used in `id="…"` attributes, and escape keyword/weather values in the test-mode HTML branches.
- Behavior preserved for legitimate data; also fixes a latent bug where a `temperature`/`precipitation` of **0** was coerced to `null` (`||` → `??`).

### Tests (new `adUtils.test.ts`, 9)
Breakout neutralization for both functions (asserts exactly one real `</script>`, payload only survives as escaped `</script>`), attribute-id escaping, test-mode HTML escaping, coordinate + zero-value handling.

### Result
Coverage **33.8% → 34.3%**; tests **718 → 727**; thresholds ratcheted. lint ✅ · type-check ✅ · build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)