### PR TITLE
fix(react-hooks): enable all 6 v7 Compiler rules with justified exceptions

### DIFF
--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -48,17 +48,14 @@ export default [
       // inline with justification.
       'react-hooks/immutability': 'error',
       'react-hooks/preserve-manual-memoization': 'error',
-
-      // Still OFF — remaining findings are idiomatic patterns the strict
-      // Compiler rules over-flag, in code CLAUDE.md marks as a frequent failure
-      // point, and the app is not on the React Compiler yet (advisory):
-      //  - set-state-in-effect: data-fetch effects (usePOILocations,
-      //    usePOINavigation) + prop→state sync (FilterManager). A real fix means
-      //    migrating to react-query / restructuring — needs sign-off.
-      //  - purity: usePOILocations computes `isStale` from Date.now() during
-      //    render (a time-derived boolean); a pure fix needs timer-based state.
-      'react-hooks/set-state-in-effect': 'off',
-      'react-hooks/purity': 'off',
+      // All 6 v7 Compiler rules now enforced. The known idiomatic exceptions are
+      // suppressed with justification at their call sites (data-fetch /
+      // prop-sync effects in usePOILocations, usePOINavigation, FilterManager;
+      // the Date.now()-derived isStale; the navigateFarther⇄expandDistanceSlice
+      // mutual reference). Enabling these catches NEW violations elsewhere
+      // (e.g. an impure Math.random()/Date.now() in render).
+      'react-hooks/set-state-in-effect': 'error',
+      'react-hooks/purity': 'error',
 
       'react-refresh/only-export-components': [
         'warn',

--- a/apps/web/src/components/FilterManager.tsx
+++ b/apps/web/src/components/FilterManager.tsx
@@ -65,8 +65,13 @@ export const useFilterManager = () => {
   // Track previous filters to prevent infinite loops
   const prevDebouncedFilters = useRef(debouncedFilters);
 
-  // Initialize instant filters from persisted filters on mount
+  // Sync external (persisted) filter changes into the instant-UI mirror.
+  // Intentional prop→state sync: `instantFilters` provides immediate UI feedback
+  // and is debounced separately for API calls, so it can't simply derive from
+  // `filters` during render. A non-effect fix would mean restructuring the
+  // debounce flow — deferred.
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setInstantFilters(filters);
   }, [filters]); // Add filters as dependency
 

--- a/apps/web/src/hooks/usePOILocations.ts
+++ b/apps/web/src/hooks/usePOILocations.ts
@@ -168,8 +168,11 @@ export function usePOILocations(options: UsePOILocationsOptions = {}) {
     }
   }, [userLocation, radius, weatherRadius, limit])
 
-  // Fetch data when dependencies change
+  // Fetch data when dependencies change. Standard data-fetch effect:
+  // fetchPOILocations sets loading/locations/error state. A "pure" alternative
+  // (react-query) is a larger migration — deferred.
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     fetchPOILocations()
   }, [fetchPOILocations])
 
@@ -188,6 +191,9 @@ export function usePOILocations(options: UsePOILocationsOptions = {}) {
     // Computed values (compatible with useWeatherLocations interface)
     hasData: locations.length > 0,
     isEmpty: !loading && locations.length === 0,
+    // Time-derived staleness flag; reading Date.now() during render is
+    // intentional (recomputes each render). A pure fix needs timer-based state.
+    // eslint-disable-next-line react-hooks/purity
     isStale: lastFetch && Date.now() - lastFetch.getTime() > 5 * 60 * 1000, // 5 minutes
 
     // POI-specific computed values

--- a/apps/web/src/hooks/usePOINavigation.ts
+++ b/apps/web/src/hooks/usePOINavigation.ts
@@ -321,9 +321,12 @@ export const usePOINavigation = (
     return newVisiblePOIs[newPOIsStartIndex] || null;
   }, [state]); // Remove function dependencies that aren't stateful
 
-  // Load data when location or filters change
+  // Load data when location or filters change. Standard data-fetch effect:
+  // loadPOIData updates POI state. A "pure" alternative (react-query) is a
+  // larger migration — deferred.
   useEffect(() => {
     if (userLocation) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       loadPOIData();
     }
   }, [userLocation, filters, loadPOIData]); // Re-enabled with proper dependencies


### PR DESCRIPTION
Completes react-hooks **v7** adoption. `set-state-in-effect` and `purity` are now **errors** — all **6 of 6** Compiler rules enforced (joining `refs`, `static-components`, `immutability`, `preserve-manual-memoization`).

The remaining findings are idiomatic/intentional patterns, **suppressed inline with justification** rather than left rule-off:
- `FilterManager` — prop→state sync for the instant-UI filter mirror
- `usePOILocations` / `usePOINavigation` — standard data-fetch effects
- `usePOILocations` `isStale` — `Date.now()`-derived staleness flag during render
- `usePOINavigation` — `navigateFarther ⇄ expandDistanceSlice` mutual reference

Why enable rather than leave off: NEW violations elsewhere are now caught (e.g. an impure `Math.random()`/`Date.now()` in render — the class of bug fixed in the AdManager — or a careless setState-in-effect). The known exceptions are explicit and documented at their sites.

### Deliberately NOT changed
The `UserLocationEstimator` `getLocationSummary` / `getFallbackLocation` "divergences" vs `locationEstimationUtils` are **divergent-by-design, not duplication**: aligning `getLocationSummary` is cosmetic-only (console.log format), and aligning `getFallbackLocation` would flip a **user-visible confidence indicator** (`'unknown'` → `'low'`) — needs explicit UI sign-off. Left as-is.

### Validation
lint ✅ (all 6 rules) · type-check ✅ · build ✅ · 733 tests ✅ · coverage ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)