### PR TITLE
fix(security): scope pre-commit secret scan to committable files

### DIFF
--- a/.github/workflows/quality-steward.yml
+++ b/.github/workflows/quality-steward.yml
@@ -98,7 +98,7 @@ jobs:
         # would let a compromised upstream execute inside it. Bump intentionally
         # after reviewing the upstream diff.
         env:
-          SKILLS_REF: 724cb9774a9e56717f1a8ab13280e2c109b76eab # bump to a reviewed commit
+          SKILLS_REF: 724cb9774a9e56717f1a8ab13280e2c109b76eab # bump to a reviewed commit  # pragma: allowlist secret (git SHA, not a credential)
         run: |
           git clone --filter=blob:none https://github.com/PrairieAster-Ai/claude-code-skills.git /tmp/ccs
           git -C /tmp/ccs checkout --quiet "$SKILLS_REF"

--- a/scripts/security/validate-env.cjs
+++ b/scripts/security/validate-env.cjs
@@ -8,6 +8,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { execFileSync } = require('child_process');
 
 // Dangerous patterns that should never appear in files
 const DANGEROUS_PATTERNS = [
@@ -124,7 +125,25 @@ class SecurityValidator {
   }
 
   shouldExcludeFile(filePath) {
-    return EXCLUDE_PATTERNS.some(pattern => pattern.test(filePath));
+    if (EXCLUDE_PATTERNS.some(pattern => pattern.test(filePath))) {
+      return true;
+    }
+    // Skip git-ignored paths (e.g. local .env / .env.local). The hook exists to
+    // stop secrets being *committed*; files git won't commit are never a leak and
+    // legitimately hold real local credentials, so scanning them just blocks every
+    // commit. Tracked/committable files are still scanned, preserving protection.
+    return this.isGitIgnored(filePath);
+  }
+
+  isGitIgnored(filePath) {
+    try {
+      // exit 0 → ignored. exit 1 (not ignored) and 128 (not a repo / git missing)
+      // both throw, and we fall back to "not ignored" so scanning still happens.
+      execFileSync('git', ['check-ignore', '--quiet', '--', filePath], { stdio: 'ignore' });
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   scanFile(filePath) {


### PR DESCRIPTION
## Problem
Two issues made `git commit` impossible without `--no-verify`:

1. **Framework broken** — the `pre_commit` Python module wasn't installed for the interpreter the git hook calls (`/usr/bin/python3 -mpre_commit`), so every commit aborted. *(Fixed in the local environment by installing `pre-commit`; this PR is the repo-side follow-up.)*
2. **`validate-env.cjs` blocked all commits** — it scans `.env`/`.env.local` for real credentials, but those are gitignored and never committed. It was flagging legitimate local secrets, failing `security-env-check` + `credential-pattern-check` on every commit.

## Changes
- **`scripts/security/validate-env.cjs`** — skip git-ignored paths via `git check-ignore`. The hook now protects only files git would actually commit; local `.env` secrets no longer block commits. Falls back to scanning if git is unavailable / not a repo (no behavior change there).
- **`.github/workflows/quality-steward.yml`** — add `# pragma: allowlist secret` to the `SKILLS_REF` git SHA so `detect-secrets` stops flagging it as a high-entropy string.

## Verification
A live `git commit` (hooks active, no `--no-verify`) passes the full chain: `detect-secrets`, `gitleaks`, `Environment Security Validation`, `Credential Pattern Check` all ✅. `validate-env.cjs` standalone scans 202 committable files and exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)