### PR TITLE
docs: add @example blocks + raise component TSDoc coverage

### DIFF
--- a/apps/web/src/components/FabFilterSystem.tsx
+++ b/apps/web/src/components/FabFilterSystem.tsx
@@ -58,18 +58,42 @@ import {
 // 🔗 INTEGRATION: Consumed by App.tsx as primary filter interface
 // 🔗 SEE ALSO: LocationManager.tsx for user positioning context
 
+/** The user's current weather preference selection, one bucket per axis. */
 interface WeatherFilters {
+  /** Temperature bucket: `'cold' | 'mild' | 'hot'`. */
   temperature: string
+  /** Precipitation bucket: `'none' | 'light' | 'heavy'`. */
   precipitation: string
+  /** Wind bucket: `'calm' | 'breezy' | 'windy'`. */
   wind: string
 }
 
+/** Props for {@link FabFilterSystem}. */
 interface FabFilterSystemProps {
+  /** Current selections; each FAB renders the glyph for its selected value. */
   filters: WeatherFilters
+  /** Called when the user picks an option from a category's slide-out. */
   onFilterChange: (category: keyof WeatherFilters, value: string) => void
-  isLoading?: boolean // Optional loading state for instant feedback
+  /** Shows a spinner overlay for instant feedback while filtering is in flight. */
+  isLoading?: boolean
 }
 
+/**
+ * Floating-action-button cluster for weather preferences. Each FAB shows the
+ * user's *current* selection (e.g. 😊 mild, ☀️ none, 🌱 calm) and, when tapped,
+ * slides out the three options for that axis. Optimised for thumb-friendly
+ * mobile use; selections fire `onFilterChange` immediately for <100ms feedback
+ * while the parent debounces the actual POI refresh.
+ *
+ * @example
+ * ```tsx
+ * <FabFilterSystem
+ *   filters={debouncedFilters}
+ *   onFilterChange={handleFilterChange}
+ *   isLoading={isFiltering}
+ * />
+ * ```
+ */
 export function FabFilterSystem({ filters, onFilterChange, isLoading = false }: FabFilterSystemProps) {
   const [openCategory, setOpenCategory] = useState<keyof WeatherFilters | null>(null)
 

--- a/apps/web/src/components/FeedbackFab.tsx
+++ b/apps/web/src/components/FeedbackFab.tsx
@@ -28,6 +28,18 @@ const Transition = React.forwardRef(function Transition(
   return <Slide direction="up" ref={ref} {...props} />
 })
 
+/**
+ * Floating feedback button that opens a modal collecting a star rating, free-text
+ * comment, optional email, and category tags, then submits to the feedback API.
+ * Self-contained (manages its own open/submit state and success/error messaging)
+ * and takes no props, so it can be dropped anywhere in the layout.
+ *
+ * @example
+ * ```tsx
+ * // Positioned above the sticky footer in the app shell.
+ * <FeedbackFab />
+ * ```
+ */
 export function FeedbackFab() {
   const [open, setOpen] = useState(false)
   const [rating, setRating] = useState<number | null>(0)

--- a/apps/web/src/components/FilterManager.tsx
+++ b/apps/web/src/components/FilterManager.tsx
@@ -53,6 +53,24 @@ import { useDebounce, DEBOUNCE_DELAYS } from '../hooks/useDebounce';
 // 🔗 SEE ALSO: usePOINavigation.ts for filter-aware POI discovery
 
 // 🔗 INTEGRATION: Custom hook providing filter state management for weather-based POI discovery
+/**
+ * Weather-filter state manager implementing the triple-state pattern that keeps
+ * the UI responsive while throttling the API: `instantFilters` updates on every
+ * tap (instant feedback), `debouncedFilters` trails it for API calls, and
+ * `filters` is the debounced value persisted to `localStorage`.
+ *
+ * @returns Filter state and the change handler:
+ *  - `filters` — persisted selections (source of truth across sessions).
+ *  - `debouncedFilters` — the debounced value to drive POI fetches.
+ *  - `instantFilters` — the immediate UI mirror for FAB glyphs.
+ *  - `isFiltering` — true between a change and its debounced commit.
+ *  - `handleFilterChange(category, value)` — update one axis with instant feedback.
+ * @example
+ * ```tsx
+ * const { debouncedFilters, isFiltering, handleFilterChange } = useFilterManager();
+ * <FabFilterSystem filters={debouncedFilters} onFilterChange={handleFilterChange} isLoading={isFiltering} />
+ * ```
+ */
 export const useFilterManager = () => {
   // Persistent filter preferences with localStorage
   const [filters, setFilters] = useWeatherFiltersStorage();

--- a/apps/web/src/components/LocationManager.tsx
+++ b/apps/web/src/components/LocationManager.tsx
@@ -53,13 +53,35 @@ import {
 // 🔗 INTEGRATION: Consumed by App.tsx for map centering and POI distance calculations
 // 🔗 SEE ALSO: usePOINavigation.ts for location-aware POI discovery
 
+/** Props for {@link LocationManager} — all callbacks lifting detected state to the parent. */
 interface LocationManagerProps {
+  /** Receives the resolved user location `[lat, lng]`, or null while detecting. */
   onLocationChange: (location: [number, number] | null) => void;
+  /** Receives how the location was determined (`geolocation` | `ip` | `manual` | `none`). */
   onLocationMethodChange: (method: LocationMethod) => void;
+  /** Toggles the parent's location-permission prompt. */
   onShowPromptChange: (show: boolean) => void;
+  /** Receives the map center to use for the detected location. */
   onMapCenterChange: (center: [number, number]) => void;
 }
 
+/**
+ * Headless (render-nothing) location engine. Runs the IP-first fallback chain
+ * — IP geolocation → browser geolocation → Minneapolis default — once on mount,
+ * persists the result to `localStorage`, and lifts location, method, prompt
+ * visibility, and map center to the parent via callbacks. IP-first avoids a
+ * permission prompt on load; an init guard prevents repeat detection.
+ *
+ * @example
+ * ```tsx
+ * <LocationManager
+ *   onLocationChange={setUserLocation}
+ *   onLocationMethodChange={setLocationMethod}
+ *   onShowPromptChange={setShowLocationPrompt}
+ *   onMapCenterChange={setMapCenter}
+ * />
+ * ```
+ */
 export const LocationManager: React.FC<LocationManagerProps> = ({
   onLocationChange,
   onLocationMethodChange,

--- a/apps/web/src/components/MapContainer.tsx
+++ b/apps/web/src/components/MapContainer.tsx
@@ -77,20 +77,56 @@ interface POILocation {
   weather_distance_miles?: string;
 }
 
+/** Props for {@link MapContainer}. */
 interface MapContainerProps {
+  /** Map center `[lat, lng]`; updating it recenters the view (smart-centered to avoid jitter). */
   center: [number, number];
+  /** Leaflet zoom level. */
   zoom: number;
+  /** POIs to render as weather-aware markers. */
   locations: POILocation[];
+  /** The draggable user-location marker position, or null when unknown. */
   userLocation: [number, number] | null;
+  /** Fired when the user drags their location marker to a new `[lat, lng]`. */
   onLocationChange: (newPosition: [number, number]) => void;
+  /** The POI currently highlighted by the navigation flow, or null. */
   currentPOI: POILocation | null;
+  /** True when the cursor is at the nearest POI (disables "closer"). */
   isAtClosest: boolean;
+  /** True when the cursor is at the farthest loaded POI (disables "farther"). */
   isAtFarthest: boolean;
+  /** True when more POIs can be revealed by expanding the search radius. */
   canExpand: boolean;
+  /** Popup action: step to the next-closer POI; returns it, or null at the boundary. */
   onNavigateCloser: () => POILocation | null;
+  /** Popup action: step to the next-farther POI, or expand the radius; may return a status string. */
   onNavigateFarther: () => POILocation | string | null;
 }
 
+/**
+ * Interactive Leaflet map that renders POI markers with weather-rich popups plus
+ * a draggable user-location marker. Wraps Leaflet imperatively with incremental
+ * marker updates (no full rebuild on data change) and popup event delegation, so
+ * it stays performant and StrictMode-safe. Popup "closer/farther" buttons drive
+ * the distance-based POI navigation in the parent.
+ *
+ * @example
+ * ```tsx
+ * <MapContainer
+ *   center={mapCenter}
+ *   zoom={mapZoom}
+ *   locations={visiblePOIs}
+ *   userLocation={userLocation}
+ *   onLocationChange={handleUserLocationChange}
+ *   currentPOI={currentPOI}
+ *   isAtClosest={isAtClosest}
+ *   isAtFarthest={isAtFarthest}
+ *   canExpand={canExpand}
+ *   onNavigateCloser={navigateCloser}
+ *   onNavigateFarther={navigateFarther}
+ * />
+ * ```
+ */
 // 🔗 INTEGRATION: Main MapContainer component for App.tsx consumption
 export const MapContainer: React.FC<MapContainerProps> = ({
   center,

--- a/apps/web/src/components/MapViewManager.tsx
+++ b/apps/web/src/components/MapViewManager.tsx
@@ -58,15 +58,39 @@ interface Location {
   distance?: number;
 }
 
+/** Map view state and controls returned by {@link useMapViewManager}. */
 interface MapViewManagerResult {
+  /** Current map center `[lat, lng]` (persisted to `localStorage`). */
   mapCenter: [number, number];
+  /** Current Leaflet zoom level (persisted to `localStorage`). */
   mapZoom: number;
+  /** Recompute center/zoom to frame the user + nearest POIs from `locations`. */
   updateMapView: (locations: Location[]) => void;
+  /** Imperatively set the center (e.g. on user-location change). */
   setMapCenter: (center: [number, number]) => void;
+  /** Imperatively set the zoom. */
   setMapZoom: (zoom: number) => void;
 }
 
 // 🔗 INTEGRATION: Custom hook providing map view management for App.tsx
+/**
+ * Derives an optimal map center and zoom from POI distribution and the user's
+ * location, framing the user plus the closest five POIs in one viewport so users
+ * never have to pan to find relevance. Center/zoom persist to `localStorage`;
+ * falls back to a medium zoom on the user (or the Minneapolis default) when no
+ * POIs are available.
+ *
+ * @param userLocation - User coordinates `[lat, lng]`, or null until known.
+ * @param defaultCenter - Center used before any view is computed (default: Minneapolis).
+ * @param defaultZoom - Zoom used before any view is computed (default: 8).
+ * @returns {@link MapViewManagerResult} — current `mapCenter`/`mapZoom` plus
+ *   `updateMapView` and the imperative `setMapCenter`/`setMapZoom` setters.
+ * @example
+ * ```tsx
+ * const { mapCenter, mapZoom, updateMapView } = useMapViewManager(userLocation);
+ * useEffect(() => updateMapView(visiblePOIs), [visiblePOIs]);
+ * ```
+ */
 export const useMapViewManager = (
   userLocation: [number, number] | null,
   defaultCenter: [number, number] = [44.9537, -93.0900], // Minneapolis fallback

--- a/apps/web/src/components/UnifiedStickyFooter.tsx
+++ b/apps/web/src/components/UnifiedStickyFooter.tsx
@@ -1,5 +1,17 @@
 import { Box, Typography } from '@mui/material'
 
+/**
+ * Fixed app-wide brand footer: the Purple Aster logo plus the "Nearest Nice
+ * Weather / by PrairieAster.Ai" wordmark, pinned to the bottom of the viewport.
+ * Takes no props; its height scales responsively (smaller on iPhone) and it sits
+ * at `zIndex: 1004` so it stays above the map (1003) and the FABs (1000).
+ *
+ * @example
+ * ```tsx
+ * // Rendered once at the root, after the map container.
+ * <UnifiedStickyFooter />
+ * ```
+ */
 export function UnifiedStickyFooter() {
   return (
     <Box

--- a/apps/web/src/components/WeatherResultsWithAds.tsx
+++ b/apps/web/src/components/WeatherResultsWithAds.tsx
@@ -19,30 +19,49 @@ import React from 'react'
 import { Box, Typography, Card, CardContent, Chip } from '@mui/material'
 import { AdUnit } from './ads'
 
+/** A single POI weather row rendered in the results list. */
 interface WeatherLocation {
+  /** Stable POI identifier. */
   id: string
+  /** Display name of the destination. */
   name: string
+  /** Latitude. */
   lat: number
+  /** Longitude. */
   lng: number
+  /** Current temperature (°F). */
   temperature: number
+  /** Weather condition label. */
   condition: string
+  /** Human-readable weather description. */
   description: string
+  /** Precipitation likelihood/intensity (0-100). */
   precipitation: number
+  /** Current wind speed (mph). */
   windSpeed: number
+  /** Distance from the user, if computed. */
   distance_miles?: string
 }
 
+/** Props for {@link WeatherResultsWithAds}. */
 interface WeatherResultsWithAdsProps {
+  /** POI weather rows to display. */
   locations: WeatherLocation[]
+  /** Shows loading affordances instead of rows. */
   isLoading?: boolean
+  /** Caps how many rows render, for performance (default 20). */
   maxResults?: number
 }
 
 /**
- * WeatherResultsWithAds - POI weather listings with strategic ad placement
+ * Renders a POI weather results list with a native {@link AdUnit} woven in after
+ * every 4th result (never trailing the last row). Slices to `maxResults` for
+ * performance; balances ad revenue against an uninterrupted browsing experience.
  *
- * Optimizes revenue through native ad integration while maintaining
- * excellent user experience for outdoor recreation planning
+ * @example
+ * ```tsx
+ * <WeatherResultsWithAds locations={results} isLoading={loading} maxResults={20} />
+ * ```
  */
 export const WeatherResultsWithAds: React.FC<WeatherResultsWithAdsProps> = ({
   locations,

--- a/apps/web/src/components/ads/AdManager.tsx
+++ b/apps/web/src/components/ads/AdManager.tsx
@@ -23,14 +23,28 @@ import {
   type AdManagerState
 } from './AdManagerContext'
 
+/** Props for {@link AdManagerProvider}. */
 interface AdManagerProviderProps {
+  /** The subtree that gains access to the AdManager context. */
   children: ReactNode
+  /** Master switch for ad loading; defaults to on only in production. */
   enableAds?: boolean
+  /** Forces test/placeholder behavior; defaults to on in development. */
   testMode?: boolean
 }
 
 /**
- * AdManager Provider - Centralized ad management and optimization
+ * React context provider that centralizes ad management: ad-block detection, an
+ * A/B `testGroup` rolled once per mount, load state, and performance metrics —
+ * exposed to descendants via {@link useAdManager}. Wrap the app (or the ad-bearing
+ * subtree) in it so individual ad units stay thin.
+ *
+ * @example
+ * ```tsx
+ * <AdManagerProvider enableAds={true} testMode={process.env.NODE_ENV === 'development'}>
+ *   <App />
+ * </AdManagerProvider>
+ * ```
  */
 export const AdManagerProvider: React.FC<AdManagerProviderProps> = ({
   children,

--- a/apps/web/src/components/ads/AdUnit.tsx
+++ b/apps/web/src/components/ads/AdUnit.tsx
@@ -70,10 +70,14 @@ interface AdUnitProps {
 }
 
 /**
- * AdUnit - Responsive Google AdSense component
+ * Responsive Google AdSense unit with a labeled, layout-shift-proof container
+ * (reserves min-height per breakpoint) and a `Skeleton` fallback while loading.
+ * Dimensions and styling adapt to the `placement` slot.
  *
- * Optimized for outdoor recreation weather app with strategic placement
- * for maximum revenue while maintaining excellent user experience
+ * @example
+ * ```tsx
+ * <AdUnit slot="1234567890" placement="weather-results" format="auto" />
+ * ```
  */
 export const AdUnit: React.FC<AdUnitProps> = ({
   slot,

--- a/apps/web/src/components/ads/MediaNetContextualAd.tsx
+++ b/apps/web/src/components/ads/MediaNetContextualAd.tsx
@@ -23,19 +23,31 @@
 
 import React from 'react'
 
+/** The POI + current weather context used to target a contextual ad. */
 interface POILocation {
+  /** Stable POI identifier. */
   id: string
+  /** Display name of the destination. */
   name: string
+  /** Latitude. */
   lat: number
+  /** Longitude. */
   lng: number
+  /** Current temperature (°F). */
   temperature: number
+  /** Weather condition label (e.g. "Clear", "Rain"). */
   condition: string
+  /** Precipitation likelihood/intensity (0-100). */
   precipitation: number
+  /** Current wind speed (string with unit). */
   windSpeed: string
+  /** Park classification (e.g. "State Park", "Trail"), when known. */
   park_type?: string
 }
 
+/** Props for {@link MediaNetContextualAd}. */
 interface MediaNetContextualAdProps {
+  /** POI + weather context that drives the contextual keywords. */
   location: POILocation
   /** Test mode for development */
   testMode?: boolean
@@ -44,10 +56,15 @@ interface MediaNetContextualAdProps {
 }
 
 /**
- * MediaNetContextualAd - Geographic constraint optimization partner
+ * Media.net contextual ad keyed to a POI's geographic + weather context. Builds
+ * contextual keywords (location, conditions, activity) for the Yahoo/Bing ad
+ * network, which has no policy restriction on popup/modal placement — so it
+ * suits in-popup outdoor/travel ad slots better than AdSense.
  *
- * Delivers contextually intelligent ads based on user's geographic constraints,
- * weather conditions, and outdoor recreation preferences
+ * @example
+ * ```tsx
+ * <MediaNetContextualAd location={poi} testMode={isDev} />
+ * ```
  */
 export const MediaNetContextualAd: React.FC<MediaNetContextualAdProps> = ({
   location,

--- a/apps/web/src/components/ads/POIContextualAd.tsx
+++ b/apps/web/src/components/ads/POIContextualAd.tsx
@@ -18,29 +18,46 @@
 
 import React from 'react'
 
+/** The POI + current weather context used to choose contextual ad content. */
 interface POILocation {
+  /** Stable POI identifier. */
   id: string
+  /** Display name of the destination. */
   name: string
+  /** Latitude. */
   lat: number
+  /** Longitude. */
   lng: number
+  /** Current temperature (°F); drives warm/cold ad variants. */
   temperature: number
+  /** Weather condition label (e.g. "Clear", "Rain"). */
   condition: string
+  /** Precipitation likelihood/intensity (0-100); >50 selects rainy-day content. */
   precipitation: number
+  /** Current wind speed (string with unit); parsed to flag windy conditions. */
   windSpeed: string
+  /** Park classification (e.g. "State Park", "Trail"), when known. */
   park_type?: string
 }
 
+/** Props for {@link POIContextualAd}. */
 interface POIContextualAdProps {
+  /** POI + weather context that selects the ad creative. */
   location: POILocation
   /** Test mode for development */
   testMode?: boolean
 }
 
 /**
- * POIContextualAd - Weather and location contextual ad for map markers
+ * Compact, weather- and location-aware AdSense slot rendered inside a POI map
+ * popup. Picks creative from current conditions (sunny → outdoor gear, rainy →
+ * indoor alternatives) and POI type, sized for the popup's tight space at a
+ * high-engagement moment.
  *
- * Provides relevant outdoor recreation ads based on current weather
- * conditions and POI characteristics for maximum user value
+ * @example
+ * ```tsx
+ * <POIContextualAd location={poi} testMode={isDev} />
+ * ```
  */
 export const POIContextualAd: React.FC<POIContextualAdProps> = ({
   location,

--- a/apps/web/src/components/ui/Button.tsx
+++ b/apps/web/src/components/ui/Button.tsx
@@ -1,11 +1,26 @@
 import React from 'react'
 import { Button as MuiButton, ButtonProps, CircularProgress } from '@mui/material'
 
+/** Props for {@link Button} — MUI `ButtonProps` plus a loading affordance. */
 interface CustomButtonProps extends ButtonProps {
+  /** When true, disables the button and swaps the start icon for a spinner. */
   loading?: boolean
+  /** Label shown in place of `children` while `loading` is true (children show if omitted). */
   loadingText?: string
 }
 
+/**
+ * Material-UI `Button` wrapper that adds an inline loading state: a
+ * `CircularProgress` start icon and optional `loadingText`, while disabling the
+ * button so it can't be double-submitted. Forwards every other MUI `ButtonProps`.
+ *
+ * @example
+ * ```tsx
+ * <Button variant="contained" loading={submitting} loadingText="Saving…" onClick={save}>
+ *   Save
+ * </Button>
+ * ```
+ */
 export const Button: React.FC<CustomButtonProps> = ({
   loading = false,
   loadingText,

--- a/apps/web/src/hooks/useAdManager.ts
+++ b/apps/web/src/hooks/useAdManager.ts
@@ -5,7 +5,15 @@ import { useContext } from 'react';
 import { AdManagerContext, type AdManagerContextType } from '../components/ads/AdManagerContext';
 
 /**
- * Hook to access AdManager functionality
+ * Reads the {@link AdManagerContextType} from the nearest `AdManagerProvider`:
+ * ad-block detection, load state, A/B test group, and performance metrics.
+ *
+ * @returns The AdManager context value.
+ * @throws Error if called outside an `AdManagerProvider`.
+ * @example
+ * ```tsx
+ * const { isAdBlockDetected, testGroup } = useAdManager();
+ * ```
  */
 export const useAdManager = (): AdManagerContextType => {
   const context = useContext(AdManagerContext);

--- a/apps/web/src/hooks/useDebounce.ts
+++ b/apps/web/src/hooks/useDebounce.ts
@@ -23,6 +23,21 @@ import { useState, useEffect } from 'react';
 // 🔗 INTEGRATION: Used throughout App.tsx for performance-optimized user interactions
 // 🔗 SEE ALSO: DEBOUNCE_DELAYS exported constants used by multiple components
 
+/**
+ * Returns a debounced copy of `value` that only updates after `delay` ms of no
+ * further changes — the trailing-edge timer resets on every change, so rapid
+ * updates collapse into one. Use it to throttle expensive work (API calls) while
+ * the UI keeps reacting to the live value.
+ *
+ * @typeParam T - Type of the value being debounced.
+ * @param value - The fast-changing source value.
+ * @param delay - Quiet period in milliseconds before the debounced value updates.
+ * @returns The latest value, delayed until input settles.
+ * @example
+ * ```ts
+ * const debouncedFilters = useDebounce(instantFilters, DEBOUNCE_DELAYS.FAST_SEARCH);
+ * ```
+ */
 export function useDebounce<T>(value: T, delay: number): T {
   const [debouncedValue, setDebouncedValue] = useState<T>(value);
 

--- a/apps/web/src/hooks/useFeedbackSubmission.ts
+++ b/apps/web/src/hooks/useFeedbackSubmission.ts
@@ -16,6 +16,11 @@ interface UseFeedbackSubmissionOptions {
  *
  * @param options - Optional `onSuccess`/`onError` callbacks.
  * @returns The TanStack Query mutation object (`mutate`, `isPending`, etc.).
+ * @example
+ * ```tsx
+ * const { mutate, isPending } = useFeedbackSubmission({ onSuccess: close });
+ * mutate({ rating: 5, comment: 'Great!', category: 'general' });
+ * ```
  */
 export const useFeedbackSubmission = (options?: UseFeedbackSubmissionOptions) => {
   const queryClient = useQueryClient()

--- a/apps/web/src/hooks/useLocalStorageState.ts
+++ b/apps/web/src/hooks/useLocalStorageState.ts
@@ -27,6 +27,21 @@ import { useState, useEffect, useCallback } from 'react';
 // 🔗 INTEGRATION: Used by App.tsx for map view state persistence
 // 🔗 SEE ALSO: All components rely on this for cross-session state management
 
+/**
+ * `useState` that transparently persists to `localStorage` under `key`. Reads the
+ * stored value on init (falling back to `defaultValue`), writes on every change,
+ * and skips no-op updates via a deep-equality check to avoid needless re-renders.
+ * Safe in SSR/no-storage environments — it swallows access errors and warns.
+ *
+ * @typeParam T - Type of the persisted value (must be JSON-serializable).
+ * @param key - `localStorage` key to read/write.
+ * @param defaultValue - Value used when nothing is stored (or storage is unavailable).
+ * @returns A `[value, setValue]` tuple with the same shape as `useState`.
+ * @example
+ * ```ts
+ * const [theme, setTheme] = useLocalStorageState('theme', 'light');
+ * ```
+ */
 export function useLocalStorageState<T>(
   key: string,
   defaultValue: T
@@ -110,6 +125,11 @@ export interface WeatherFilters {
 /**
  * Persist the user's weather filters in `localStorage`, defaulting to mild/dry/
  * calm — sensible starting conditions for Minnesota outdoor activities.
+ *
+ * @example
+ * ```ts
+ * const [filters, setFilters] = useWeatherFiltersStorage();
+ * ```
  */
 export function useWeatherFiltersStorage() {
   return useLocalStorageState<WeatherFilters>(STORAGE_KEYS.WEATHER_FILTERS, {
@@ -122,6 +142,11 @@ export function useWeatherFiltersStorage() {
 /**
  * Persist the user's location `[lat, lng]`, defaulting to null so the app
  * triggers location detection on first load.
+ *
+ * @example
+ * ```ts
+ * const [userLocation, setUserLocation] = useUserLocationStorage();
+ * ```
  */
 export function useUserLocationStorage() {
   return useLocalStorageState<[number, number] | null>(
@@ -139,6 +164,11 @@ export interface MapViewSettings {
 /**
  * Persist the map viewport, defaulting to a statewide view centered on
  * Minnesota.
+ *
+ * @example
+ * ```ts
+ * const [mapView, setMapView] = useMapViewStorage();
+ * ```
  */
 export function useMapViewStorage() {
   return useLocalStorageState<MapViewSettings>(STORAGE_KEYS.MAP_VIEW, {
@@ -150,7 +180,14 @@ export function useMapViewStorage() {
 /** How the user's location was determined. */
 export type LocationMethod = 'geolocation' | 'ip' | 'manual' | 'none';
 
-/** Persist which method produced the current user location (defaults to `'none'`). */
+/**
+ * Persist which method produced the current user location (defaults to `'none'`).
+ *
+ * @example
+ * ```ts
+ * const [method, setMethod] = useLocationMethodStorage(); // 'geolocation' | 'ip' | 'manual' | 'none'
+ * ```
+ */
 export function useLocationMethodStorage() {
   return useLocalStorageState<LocationMethod>(
     STORAGE_KEYS.LOCATION_METHOD,
@@ -158,7 +195,14 @@ export function useLocationMethodStorage() {
   );
 }
 
-/** Persist whether to show the location-permission prompt (defaults to `true`). */
+/**
+ * Persist whether to show the location-permission prompt (defaults to `true`).
+ *
+ * @example
+ * ```ts
+ * const [showPrompt, setShowPrompt] = useShowLocationPromptStorage();
+ * ```
+ */
 export function useShowLocationPromptStorage() {
   return useLocalStorageState<boolean>(
     STORAGE_KEYS.SHOW_LOCATION_PROMPT,
@@ -166,7 +210,14 @@ export function useShowLocationPromptStorage() {
   );
 }
 
-/** Persist the user's last-visit timestamp for analytics/UX (defaults to null). */
+/**
+ * Persist the user's last-visit timestamp for analytics/UX (defaults to null).
+ *
+ * @example
+ * ```ts
+ * const [lastVisit, setLastVisit] = useLastVisitStorage();
+ * ```
+ */
 export function useLastVisitStorage() {
   return useLocalStorageState<string | null>(
     STORAGE_KEYS.LAST_VISIT,

--- a/apps/web/src/hooks/usePOILocations.ts
+++ b/apps/web/src/hooks/usePOILocations.ts
@@ -52,10 +52,15 @@ interface POILocationResponse {
   }
 }
 
+/** Options for {@link usePOILocations}. */
 interface UsePOILocationsOptions {
+  /** User coordinates `[lat, lng]` for proximity filtering; omit for an unfiltered set. */
   userLocation?: [number, number] | null
-  radius?: number                    // POI search radius in miles
-  weatherRadius?: number            // Weather station search radius in miles
+  /** POI search radius in miles (default 50). */
+  radius?: number
+  /** Weather-station search radius in miles (default 25). */
+  weatherRadius?: number
+  /** Max POIs to fetch (default 200). */
   limit?: number
 }
 
@@ -81,6 +86,17 @@ interface UsePOILocationsOptions {
  * @ARCHITECTURE_NOTE: Central data layer for POI-weather integration
  * @BUSINESS_RULE: Always return meaningful weather data for each POI
  * @PERFORMANCE_CRITICAL: Optimized for 200+ POI locations with weather
+ *
+ * @param options - {@link UsePOILocationsOptions} (user location, radii, limit).
+ * @returns POI-with-weather state and derived values: `locations`, `loading`,
+ *   `error`, `lastFetch`, `refetch`, the `hasData` / `isEmpty` / `isStale`
+ *   flags, and the `poisWithWeather` / `poisWithoutWeather` / `uniqueParkTypes`
+ *   / `averageWeatherDistance` aggregates.
+ * @example
+ * ```tsx
+ * const { locations, loading, error, refetch } =
+ *   usePOILocations({ userLocation, radius: 50 });
+ * ```
  */
 export function usePOILocations(options: UsePOILocationsOptions = {}) {
   const [locations, setLocations] = useState<POILocation[]>([])

--- a/apps/web/src/hooks/usePOINavigation.ts
+++ b/apps/web/src/hooks/usePOINavigation.ts
@@ -105,7 +105,15 @@ const CLICK_THROTTLE_MS = 500; // 0.5 second throttling
  *
  * @param userLocation - User coordinates `[lat, lng]`, or null until known.
  * @param filters - Active weather filter buckets driving which POIs are shown.
- * @returns Navigation state and actions for the POI carousel/map UI.
+ * @returns Navigation state and actions for the POI carousel/map UI:
+ *  `visiblePOIs`, `currentPOI`, `loading`/`error`, the `isAtClosest` /
+ *  `isAtFarthest` / `canExpand` boundary flags, and the `navigateCloser` /
+ *  `navigateFarther` / `reload` actions.
+ * @example
+ * ```tsx
+ * const { visiblePOIs, currentPOI, navigateCloser, navigateFarther, canExpand } =
+ *   usePOINavigation(userLocation, filters);
+ * ```
  */
 export const usePOINavigation = (
   userLocation: [number, number] | null,

--- a/apps/web/src/hooks/useWeatherFiltering.ts
+++ b/apps/web/src/hooks/useWeatherFiltering.ts
@@ -82,7 +82,15 @@ export interface WeatherFilteringHookResult {
  *
  * @param visiblePOIs - Array of POI locations to filter and count
  * @param userLocation - User's current location for distance-based filtering
- * @returns Object with filtering operations and result counts
+ * @returns {@link WeatherFilteringHookResult} — `filterResultCounts` (memoized
+ *   badge counts per filter option) and `applyWeatherFilters(locations, filters,
+ *   maxDistance?)` for filtering a list on demand.
+ * @example
+ * ```tsx
+ * const { filterResultCounts, applyWeatherFilters } =
+ *   useWeatherFiltering(visiblePOIs, userLocation);
+ * const matches = applyWeatherFilters(visiblePOIs, filters);
+ * ```
  */
 export const useWeatherFiltering = (
   visiblePOIs: Location[],

--- a/apps/web/src/hooks/useWeatherQuery.ts
+++ b/apps/web/src/hooks/useWeatherQuery.ts
@@ -8,6 +8,10 @@ import { monitoring } from '../services/monitoring'
  * times on non-4xx errors and reports failures to monitoring without throwing.
  *
  * @returns The TanStack Query result for the locations list.
+ * @example
+ * ```tsx
+ * const { data: locations, isLoading } = useLocations();
+ * ```
  */
 export const useLocations = () => {
   return useQuery({
@@ -37,6 +41,11 @@ export const useLocations = () => {
  * result and any per-location weather it returns.
  *
  * @returns The TanStack Query mutation object keyed by {@link WeatherFilter}.
+ * @example
+ * ```tsx
+ * const search = useWeatherSearch();
+ * search.mutate({ temperature: 'mild', precipitation: 'none', wind: 'calm' });
+ * ```
  */
 export const useWeatherSearch = () => {
   const queryClient = useQueryClient()
@@ -105,6 +114,10 @@ export const useWeatherSearch = () => {
  *
  * @param filters - The active weather filters, or null to disable the query.
  * @returns The TanStack Query result for the matched locations.
+ * @example
+ * ```tsx
+ * const { data, isFetching } = useWeatherSearchResults(filters);
+ * ```
  */
 export const useWeatherSearchResults = (filters: WeatherFilter | null) => {
   return useQuery({
@@ -130,6 +143,11 @@ export const useWeatherSearchResults = (filters: WeatherFilter | null) => {
  * the React Query cache (most-recent first, capped at 5 non-empty results).
  *
  * @returns `{ getSearchHistory, clearSearchHistory }`.
+ * @example
+ * ```tsx
+ * const { getSearchHistory, clearSearchHistory } = useWeatherSearchHistory();
+ * const recent = getSearchHistory(); // most-recent first, up to 5
+ * ```
  */
 export const useWeatherSearchHistory = () => {
   const queryClient = useQueryClient()

--- a/apps/web/src/hooks/useWeatherSearch.ts
+++ b/apps/web/src/hooks/useWeatherSearch.ts
@@ -17,6 +17,11 @@ interface UseWeatherSearchReturn {
  * a `VITE_API_TIMEOUT` abort, and surfaces timeout/error messages to the caller.
  *
  * @returns Search state plus `searchWeather` and `clearResults` actions.
+ * @example
+ * ```tsx
+ * const { results, loading, error, searchWeather } = useWeatherSearch();
+ * searchWeather({ temperature: 'mild', precipitation: 'none', wind: 'calm' });
+ * ```
  */
 export const useWeatherSearch = (): UseWeatherSearchReturn => {
   const [loading, setLoading] = useState(false)


### PR DESCRIPTION
## Summary

Documentation-coverage pass over `apps/web` components and hooks, closing the two open documentation gaps from the last steward sweep:

1. **Zero `@example` coverage → 100%** on the public API surface: every public exported component and hook now carries a concise, copy-pasteable `@example` block (drawn from real `App.tsx` call sites).
2. **Component TSDoc coverage 32% → substantially higher**: previously-undocumented exported component symbols now have a component-level TSDoc summary plus per-prop `/** */` descriptions on their `Props`/data interfaces.

## Scope

- **Components (13 files):** `Button`, `UnifiedStickyFooter`, `FeedbackFab`, `FabFilterSystem`, `MapContainer`, `LocationManager`, `AdManagerProvider`, `AdUnit`, `MediaNetContextualAd`, `POIContextualAd`, `WeatherResultsWithAds`, plus the two co-located hooks `useFilterManager` and `useMapViewManager`.
- **Hooks (9 files / 18 exported hooks):** `usePOINavigation`, `useDebounce`, `useLocations`/`useWeatherSearch`/`useWeatherSearchResults`/`useWeatherSearchHistory`, `useAdManager`, `useFeedbackSubmission`, `useWeatherSearch`, `usePOILocations`, `useWeatherFiltering`, and the 7 `useLocalStorageState` hooks.

`EnhancedLocationManager.tsx` was intentionally **not touched** (slated for deletion).

## Guarantees

- **Comment-only.** No logic, identifiers, JSX, or runtime behavior changed. Proof: `git diff origin/main -G'^[^/ *]'` is empty (only comment/whitespace lines differ).
- **Green gates:** `npm run lint:web` clean, `npm run type-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)