### PR TITLE
docs: raise TSDoc coverage on utils/config (code-readability pass)

### DIFF
--- a/apps/web/src/config/performanceRequirements.ts
+++ b/apps/web/src/config/performanceRequirements.ts
@@ -30,11 +30,17 @@ import performanceConfig from './PERFORMANCE-REQUIREMENTS.json';
  * boundary in the given `unit`, with optional business-rule/scaling notes.
  */
 export interface PerformanceMetric {
+  /** Ideal value to aim for; passing tests should stay at or below this. */
   target: number;
+  /** Failing boundary; exceeding this is treated as a regression. */
   max: number;
+  /** Unit the `target`/`max` numbers are expressed in. */
   unit: 'ms' | 's';
+  /** Human-readable explanation of what this metric measures. */
   description: string;
+  /** Optional business rationale tying the threshold to a user/engagement outcome. */
   businessRule?: string;
+  /** Optional note on how the threshold should change as data volume or scale grows. */
   scalingNote?: string;
 }
 

--- a/apps/web/src/types/feedback.ts
+++ b/apps/web/src/types/feedback.ts
@@ -1,17 +1,30 @@
+/**
+ * Type contracts for the user-feedback feature: the form payload, the API
+ * response, the persisted database row, and the Zod schema that validates
+ * incoming submissions. Shared by the feedback form, the submission hook, and
+ * the feedback API handler so client and server agree on the shape.
+ */
 import { z } from 'zod'
 
 /** User-submitted feedback as captured by the feedback form. */
 export interface FeedbackFormData {
+  /** Star rating from 1 (worst) to 5 (best). */
   rating: number
+  /** Free-text feedback body. */
   comment: string
+  /** Optional reply-to email address. */
   email?: string
+  /** What kind of feedback this is. */
   category: 'bug' | 'feature' | 'general'
 }
 
 /** API response returned after a feedback submission succeeds. */
 export interface FeedbackSubmissionResponse {
+  /** Whether the submission was accepted. */
   success: boolean
+  /** Human-readable status message. */
   message: string
+  /** Database id assigned to the new feedback record. */
   id: number
 }
 
@@ -20,14 +33,23 @@ export interface FeedbackSubmissionResponse {
  * server-captured request metadata and timestamps.
  */
 export interface FeedbackRecord {
+  /** Database primary key. */
   id: number
+  /** Star rating from 1 to 5. */
   rating: number
+  /** Free-text feedback body. */
   comment: string
+  /** Optional reply-to email address. */
   email?: string
+  /** What kind of feedback this is. */
   category: 'bug' | 'feature' | 'general'
+  /** Browser user-agent captured server-side at submission time. */
   user_agent?: string
+  /** Client IP address captured server-side at submission time. */
   ip_address?: string
+  /** ISO-8601 creation timestamp. */
   created_at: string
+  /** ISO-8601 last-update timestamp. */
   updated_at: string
 }
 

--- a/apps/web/src/types/weather.ts
+++ b/apps/web/src/types/weather.ts
@@ -1,3 +1,8 @@
+/**
+ * Zod schemas, inferred types, and React Query cache keys for the weather/POI
+ * domain. The schemas are the single source of truth: the exported types are
+ * inferred from them, so runtime validation and compile-time types can't drift.
+ */
 import { z } from 'zod'
 
 /**
@@ -51,8 +56,11 @@ export type WeatherSearchResponse = z.infer<typeof WeatherSearchResponseSchema>
 
 /** Normalized error returned by the weather API layer. */
 export interface ApiError {
+  /** Human-readable error message. */
   message: string
+  /** HTTP status code, when the error originated from an HTTP response. */
   status?: number
+  /** Stable machine-readable error code, when available. */
   code?: string
 }
 

--- a/apps/web/src/utils/adUtils.ts
+++ b/apps/web/src/utils/adUtils.ts
@@ -1,13 +1,26 @@
 // Ad Utilities
 // Helper functions for generating contextual advertising content
+//
+// The HTML builders here embed POI-derived data into inline <script> blocks, so
+// every dynamic value is routed through toScriptJson / escapeHtmlAttr to prevent
+// a malicious POI name from breaking out of the script element (see the
+// per-function notes below).
 
+/** The POI fields the ad builders read to derive weather-aware, geo-targeted ad keywords. */
 export interface POILocation {
+  /** Stable unique identifier for the POI (used to namespace ad container ids). */
   id: string;
+  /** POI name, surfaced in ad targeting context. */
   name: string;
+  /** Optional temperature in °F, used to pick seasonal keywords. */
   temperature?: number;
+  /** Optional precipitation probability (0–100), used to pick gear keywords. */
   precipitation?: number;
+  /** Optional park classification (e.g. "State Park", "Trail"), used for activity keywords. */
   park_type?: string;
+  /** Latitude in decimal degrees. */
   latitude: number;
+  /** Longitude in decimal degrees. */
   longitude: number;
 }
 

--- a/apps/web/src/utils/contextualWeatherIntelligence.ts
+++ b/apps/web/src/utils/contextualWeatherIntelligence.ts
@@ -1,44 +1,102 @@
-// Contextual Weather Intelligence for Subjective "Nearest Nice Weather"
-// Transforms static filtering into adaptive discovery
+/**
+ * ========================================================================
+ * CONTEXTUAL WEATHER INTELLIGENCE
+ * ========================================================================
+ *
+ * Scores "nearest nice weather" subjectively instead of with static filters:
+ * how *near* and how *nice* a destination is are both relative to the user's
+ * context (intended activity, season, travel willingness) and to the other
+ * options currently available.
+ *
+ * @remarks
+ * This is a standalone scoring engine and is not currently wired into the app's
+ * POI navigation path (no imports outside this module). Treat it as an
+ * experimental/alternative discovery strategy; the live filtering lives in
+ * {@link ../utils/weatherFilteringUtils} and {@link ../utils/poiNavigationUtils}.
+ */
 
+/** An outdoor destination plus its current weather, the unit this engine scores. */
 export interface WeatherLocation {
+  /** Stable unique identifier for the location. */
   id: string
+  /** Human-readable location name. */
   name: string
+  /** Latitude in decimal degrees. */
   lat: number
+  /** Longitude in decimal degrees. */
   lng: number
+  /** Temperature in degrees Fahrenheit. */
   temperature: number
+  /** Short condition label (e.g. "Clear", "Overcast"). */
   condition: string
+  /** Longer human-readable weather description. */
   description: string
+  /** Precipitation probability as a 0–100 percentage. */
   precipitation: number
+  /** Wind speed in miles per hour. */
   windSpeed: number
 }
 
+/** The user's situation, used to make "near" and "nice" subjective rather than absolute. */
 export interface UserContext {
+  /** User's current position as `[latitude, longitude]`; when omitted, all destinations are treated as equally near. */
   currentLocation?: [number, number]
+  /** Part of day, for time-aware adjustments. */
   timeOfDay?: 'morning' | 'afternoon' | 'evening' | 'night'
+  /** Season, used to compare conditions against seasonal norms. */
   season?: 'spring' | 'summer' | 'fall' | 'winter'
+  /** Activity the user intends to do, which sets the optimal weather band. */
   intendedActivity?: 'hiking' | 'fishing' | 'photography' | 'camping' | 'sightseeing' | 'general'
+  /** How strongly weather quality should influence scoring. */
   weatherSensitivity?: 'low' | 'moderate' | 'high'
+  /** Maximum distance the user is willing to travel, in miles. */
   travelWillingness?: number // miles willing to travel
+  /** Required on-site infrastructure level. */
   infrastructure?: 'any' | 'basic' | 'full_services'
 }
 
+/** A scored recommendation for one location, with human-readable reasoning and comparative context. */
 export interface ContextualAssessment {
+  /** The location this assessment is for. */
   location: WeatherLocation
+  /** 0–1 score for how contextually "near" the location is. */
   nearnessFit: number // 0-1 score for contextual "nearness"
+  /** 0–1 score for how contextually "nice" the weather is. */
   nicenessFit: number // 0-1 score for contextual "niceness"
+  /** Combined nearness/niceness score used for ranking. */
   overallScore: number
+  /** Plain-language explanations behind each score, plus any concerns. */
   reasoning: {
+    /** Why this location scored as it did on nearness. */
     nearness: string[]
+    /** Why this location scored as it did on niceness. */
     niceness: string[]
+    /** Notable downsides to flag to the user. */
     concerns: string[]
   }
+  /** How this location stacks up against the other candidates. */
   comparisonContext: {
+    /** Percentage of the other options this location beats. */
     betterThan: number // percentage of other options this beats
+    /** Standout advantages relative to alternatives. */
     uniqueAdvantages: string[]
   }
 }
 
+/**
+ * Engine that turns a list of {@link WeatherLocation}s plus a {@link UserContext}
+ * into ranked, explained recommendations.
+ *
+ * @example
+ * ```ts
+ * const engine = new ContextualWeatherIntelligence();
+ * const ranked = engine.generateContextualRecommendations(locations, {
+ *   currentLocation: [44.95, -93.09],
+ *   intendedActivity: 'hiking',
+ *   travelWillingness: 120,
+ * });
+ * ```
+ */
 export class ContextualWeatherIntelligence {
   private seasonalNorms = {
     spring: { temp: [50, 70], precip: [20, 40], wind: [8, 15] },
@@ -74,6 +132,14 @@ export class ContextualWeatherIntelligence {
     }
   }
 
+  /**
+   * Score how contextually "near" a destination is, blending raw distance with
+   * context (e.g. campers tolerate longer drives).
+   * @param userLocation - User's position, or `undefined` to treat all destinations as equally accessible.
+   * @param destination - The candidate destination being scored.
+   * @param context - User context that adjusts distance tolerance.
+   * @returns A 0–1 `score` (higher is nearer-feeling) plus `reasoning` strings explaining it.
+   */
   calculateContextualNearness(
     userLocation: [number, number] | undefined,
     destination: WeatherLocation,
@@ -112,6 +178,15 @@ export class ContextualWeatherIntelligence {
     return { score: Math.min(1.0, score), reasoning }
   }
 
+  /**
+   * Score how contextually "nice" a location's weather is for the user's intended
+   * activity, judging temperature, precipitation, wind, and condition against the
+   * activity's optimal band and the rest of the candidate set.
+   * @param weather - The location whose weather is being judged.
+   * @param context - User context supplying the activity and season.
+   * @param allLocations - The full candidate set, used for comparative ranking.
+   * @returns A 0–1 `score` (higher is nicer) plus `reasoning` strings explaining it.
+   */
   calculateWeatherNiceness(
     weather: WeatherLocation,
     context: UserContext,
@@ -185,6 +260,15 @@ export class ContextualWeatherIntelligence {
     return { score: Math.max(0, Math.min(1, score)), reasoning }
   }
 
+  /**
+   * Score every candidate location and return them ranked best-first.
+   *
+   * The overall score weights niceness over nearness (0.6 / 0.4), so a meaningfully
+   * better-weather destination can outrank a closer one within the user's travel budget.
+   * @param locations - Candidate destinations to assess.
+   * @param userContext - The user's situation driving the scoring.
+   * @returns Assessments sorted by descending {@link ContextualAssessment.overallScore}.
+   */
   generateContextualRecommendations(
     locations: WeatherLocation[],
     userContext: UserContext

--- a/apps/web/src/utils/loadAnalytics.ts
+++ b/apps/web/src/utils/loadAnalytics.ts
@@ -3,12 +3,20 @@
  * Loads analytics script based on environment variables
  */
 
+/** Resolved Umami configuration needed to inject the analytics script tag. */
 interface UmamiConfig {
+  /** URL of the hosted Umami tracker script. */
   scriptUrl: string;
+  /** Umami website id this deployment reports under. */
   websiteId: string;
+  /** Comma-separated allowlist of domains Umami should track. */
   domains: string;
 }
 
+/**
+ * Read Umami settings from Vite env vars.
+ * @returns A complete {@link UmamiConfig}, or `null` when the required env vars are absent (analytics disabled).
+ */
 const getUmamiConfig = (): UmamiConfig | null => {
   const scriptUrl = import.meta.env.VITE_UMAMI_SCRIPT_URL;
   const websiteId = import.meta.env.VITE_UMAMI_WEBSITE_ID;
@@ -25,6 +33,20 @@ const getUmamiConfig = (): UmamiConfig | null => {
   };
 };
 
+/**
+ * Lazily inject the Umami analytics script, once, based on environment config.
+ *
+ * Resolves rather than rejects on every outcome so callers never need a try/catch:
+ * the boolean tells you whether tracking is active.
+ *
+ * @returns A promise resolving `true` when the script is loaded (or already present),
+ * and `false` when analytics is disabled (missing env vars) or the script failed to load.
+ * @example
+ * ```ts
+ * const tracking = await loadUmamiAnalytics();
+ * if (tracking) console.log('Umami active');
+ * ```
+ */
 export const loadUmamiAnalytics = (): Promise<boolean> => {
   return new Promise((resolve) => {
     const config = getUmamiConfig();

--- a/apps/web/src/utils/locationEstimationUtils.ts
+++ b/apps/web/src/utils/locationEstimationUtils.ts
@@ -26,6 +26,12 @@
  */
 
 // Constants for location estimation
+
+/**
+ * Accuracy (meters) and age (minutes) ceilings that map a fix onto a
+ * {@link LocationConfidence} level in {@link calculateConfidence}. A fix must beat
+ * both the accuracy and age bound of a tier to qualify for it.
+ */
 export const LOCATION_CONFIDENCE_THRESHOLDS = {
   HIGH_ACCURACY_METERS: 50,
   HIGH_AGE_MINUTES: 5,
@@ -34,6 +40,11 @@ export const LOCATION_CONFIDENCE_THRESHOLDS = {
   LOW_ACCURACY_METERS: 10000,
 } as const;
 
+/**
+ * Heuristic IP-geolocation accuracy estimates (meters), tuned for Minnesota.
+ * Urban areas resolve more tightly than rural; the `GENERAL_*` values are the
+ * fallback when the location can't be classified as Minnesota-specific.
+ */
 export const MINNESOTA_ACCURACY_ESTIMATES = {
   URBAN_METERS: 3000,    // ~3km for Minnesota urban areas
   RURAL_METERS: 15000,   // ~15km for rural Minnesota
@@ -41,6 +52,7 @@ export const MINNESOTA_ACCURACY_ESTIMATES = {
   GENERAL_RURAL_METERS: 25000,  // ~25km for rural areas
 } as const;
 
+/** Numeric weight per {@link LocationConfidence} level, used when scoring/comparing estimates. */
 export const CONFIDENCE_SCORES = {
   high: 100,
   medium: 75,
@@ -48,6 +60,7 @@ export const CONFIDENCE_SCORES = {
   unknown: 25
 } as const;
 
+/** Numeric weight per {@link LocationMethod}, ranking sources from most trusted (gps) to least (none). */
 export const METHOD_SCORES = {
   gps: 100,
   network: 80,
@@ -59,6 +72,8 @@ export const METHOD_SCORES = {
 } as const;
 
 // Type definitions (extracted from UserLocationEstimator)
+
+/** How a user location was obtained, ordered roughly from most to least accurate. */
 export type LocationMethod =
   | 'gps'           // High accuracy GPS
   | 'network'       // Network-based (WiFi/cell towers)
@@ -68,14 +83,22 @@ export type LocationMethod =
   | 'fallback'     // Default Minneapolis center
   | 'none';        // No location available
 
+/** Coarse trust level for a location fix, derived from its accuracy and age. */
 export type LocationConfidence = 'high' | 'medium' | 'low' | 'unknown';
 
+/** A single resolved user-location candidate, with the metadata needed to score and compare it. */
 export interface LocationEstimate {
+  /** Resolved position as `[latitude, longitude]` in decimal degrees. */
   coordinates: [number, number]; // [latitude, longitude]
+  /** Approximate accuracy radius in meters (smaller is better). */
   accuracy: number; // Accuracy in meters (approximate)
+  /** How the fix was obtained. */
   method: LocationMethod;
+  /** When the fix was taken, as a Unix epoch timestamp in milliseconds. */
   timestamp: number; // Unix timestamp
+  /** Derived trust level for this fix. */
   confidence: LocationConfidence;
+  /** Optional free-form source identifier (e.g. the IP-geolocation provider). */
   source?: string; // Optional source identifier
 }
 

--- a/apps/web/src/utils/locationUtils.ts
+++ b/apps/web/src/utils/locationUtils.ts
@@ -26,17 +26,26 @@
  * LAST UPDATED: 2025-08-13
  */
 
+/** How the current user location was obtained (`'none'` means no location yet). */
 export type LocationMethod = 'none' | 'gps' | 'ip' | 'manual' | 'cached'
 
+/** The app's user-location state as persisted and rendered: position, its source, and whether to prompt the user. */
 export interface LocationState {
+  /** Current position as `[latitude, longitude]`, or `null` when unknown. */
   userLocation: [number, number] | null
+  /** How {@link LocationState.userLocation} was obtained. */
   locationMethod: LocationMethod
+  /** Whether to show the "share your location" prompt to the user. */
   showLocationPrompt: boolean
 }
 
+/** A single location-change event: the new position, its source, and when it occurred. */
 export interface LocationUpdate {
+  /** New position as `[latitude, longitude]`. */
   position: [number, number]
+  /** How the new position was obtained. */
   method: LocationMethod
+  /** ISO-8601 timestamp of when the update happened. */
   timestamp: string
 }
 

--- a/apps/web/src/utils/mapIcons.ts
+++ b/apps/web/src/utils/mapIcons.ts
@@ -4,6 +4,18 @@
 import L from 'leaflet';
 
 // 🔗 INTEGRATION: Aster icon for consistent branding across map components
+/**
+ * Shared Leaflet marker icon (the PrairieAster "aster" SVG) used for POI markers
+ * so branding stays consistent across every map component.
+ *
+ * @remarks Anchored at its center (`iconAnchor` = half of `iconSize`) so the marker
+ * sits exactly on the POI's coordinates; the popup opens just above it.
+ * @example
+ * ```tsx
+ * import { asterIcon } from '../utils/mapIcons';
+ * <Marker position={[lat, lng]} icon={asterIcon} />
+ * ```
+ */
 export const asterIcon = new L.Icon({
   iconUrl: '/aster-marker.svg',
   iconSize: [40, 40],

--- a/apps/web/src/utils/mapViewCalculations.ts
+++ b/apps/web/src/utils/mapViewCalculations.ts
@@ -24,15 +24,23 @@
  * LAST UPDATED: 2025-08-13
  */
 
+/** Minimal location shape needed to compute a map view: an identifiable point with coordinates. */
 export interface LocationPoint {
+  /** Stable unique identifier for the point. */
   id: string
+  /** Human-readable name (for debugging / labels). */
   name: string
+  /** Latitude in decimal degrees. */
   lat: number
+  /** Longitude in decimal degrees. */
   lng: number
 }
 
+/** A resolved Leaflet map view: where to center and how far to zoom. */
 export interface MapViewBounds {
+  /** Map center as `[latitude, longitude]`. */
   center: [number, number]
+  /** Leaflet zoom level (higher is closer in). */
   zoom: number
 }
 

--- a/apps/web/src/utils/poiNavigationUtils.ts
+++ b/apps/web/src/utils/poiNavigationUtils.ts
@@ -26,38 +26,70 @@
  */
 
 // Distance calculation constants
+
+/** Width of each distance band, in miles, used to group POIs for progressive reveal (0–30mi, 30–60mi, …). */
 export const DISTANCE_SLICE_SIZE = 30; // 30 mile slices
+/** Earth's mean radius in miles, used by the Haversine distance calculation. */
 export const EARTH_RADIUS_MILES = 3959; // Earth's radius in miles
 
 // Data processing constants
+
+/** Maximum number of POIs returned/processed per request; mirrors the API's hard limit. */
 export const MAX_RESULTS = 50; // Hard-coded API limit
 
 // Type definitions (extracted from usePOINavigation)
+
+/**
+ * A POI enriched with the derived fields the navigation algorithm needs:
+ * distance from the user, which distance slice it falls in, and whether it is
+ * currently revealed in the UI.
+ */
 export interface POIWithMetadata {
+  /** Stable unique identifier for the POI. */
   id: string;
+  /** Human-readable POI name. */
   name: string;
+  /** Latitude in decimal degrees. */
   lat: number;
+  /** Longitude in decimal degrees. */
   lng: number;
+  /** Temperature in degrees Fahrenheit. */
   temperature: number;
+  /** Precipitation probability as a 0–100 percentage. */
   precipitation: number;
+  /** Wind speed in mph; arrives as a string from the API and is kept as-is. */
   windSpeed: string; // Wind speed in mph (string from API)
+  /** Short condition label (e.g. "Clear"). */
   condition: string;
+  /** Longer human-readable weather description. */
   description: string;
+  /** Great-circle distance from the user's location, in miles. */
   distance: number;
+  /** Whether this POI is currently revealed in the UI (vs. held back for later expansion). */
   displayed: boolean;
+  /** Zero-based distance-band index ({@link DISTANCE_SLICE_SIZE}-mile bands). */
   sliceIndex: number;
 }
 
+/** Result of processing a raw POI list: the enriched POIs plus summary distance statistics. */
 export interface POIProcessingResult {
+  /** POIs enriched with distance/slice/display metadata, sorted nearest-first. */
   processedPOIs: POIWithMetadata[];
+  /** Total number of POIs in the processed set. */
   totalCount: number;
+  /** Distance to the nearest POI, in miles. */
   closestDistance: number;
+  /** Distance to the farthest POI, in miles. */
   farthestDistance: number;
 }
 
+/** Server-side weather filter parameters sent with a POI query (temperature range + acceptable conditions). */
 export interface WeatherFilters {
+  /** Minimum acceptable temperature in °F. */
   temp_min: number;
+  /** Maximum acceptable temperature in °F. */
   temp_max: number;
+  /** Acceptable condition labels (e.g. `['Clear', 'Partly Cloudy']`). */
   conditions: string[];
 }
 

--- a/apps/web/src/utils/validation.ts
+++ b/apps/web/src/utils/validation.ts
@@ -1,3 +1,8 @@
+/**
+ * Input-sanitization and validation helpers shared across forms and API
+ * boundaries: best-effort XSS stripping, HTML encoding, and Zod-backed schema
+ * validation. Defense-in-depth — pair with proper output encoding at render time.
+ */
 import { z } from 'zod'
 
 /**

--- a/apps/web/src/utils/weatherFilteringUtils.ts
+++ b/apps/web/src/utils/weatherFilteringUtils.ts
@@ -25,9 +25,24 @@
  * @CLAUDE_CONTEXT: Pure function extraction for comprehensive weather filtering testing
  */
 
-// Constants for weather filtering
+/** Earth's mean radius in miles, used by the Haversine distance calculation. */
 export const EARTH_RADIUS_MILES = 3959;
 
+/**
+ * Percentile cut points that turn an absolute weather distribution into the
+ * coarse cold/mild/hot, dry/light/heavy, calm/breezy/windy buckets the UI filters on.
+ *
+ * @remarks
+ * These are intentionally relative (percentile-based), not absolute thresholds:
+ * "mild" means the middle of whatever the current result set looks like, not a
+ * fixed temperature. Changing these values directly changes how restrictive each
+ * filter feels, so treat them as product-tuning knobs and adjust only on request.
+ * @example
+ * ```ts
+ * // Coldest 40% of locations qualify as "cold"
+ * const isCold = percentileRank <= WEATHER_PERCENTILES.COLD_THRESHOLD;
+ * ```
+ */
 export const WEATHER_PERCENTILES = {
   // Temperature filtering percentiles
   COLD_THRESHOLD: 0.4,     // Coldest 40%
@@ -49,48 +64,83 @@ export const WEATHER_PERCENTILES = {
 } as const;
 
 // Type definitions
+
+/** A geographic point expressed as `[latitude, longitude]` in decimal degrees. */
 export type Coordinates = [number, number]; // [latitude, longitude]
 
+/** An outdoor recreation location with the weather fields needed for filtering and sorting. */
 export interface Location {
+  /** Stable unique identifier for the POI. */
   id: string;
+  /** Human-readable POI name (e.g. "Gooseberry Falls State Park"). */
   name: string;
+  /** Latitude in decimal degrees. */
   lat: number;
+  /** Longitude in decimal degrees. */
   lng: number;
+  /** Temperature in degrees Fahrenheit. */
   temperature: number;
+  /** Precipitation probability as a 0–100 percentage. */
   precipitation: number;
+  /** Wind speed in miles per hour. */
   windSpeed: number;
+  /** Short condition label (e.g. "Clear", "Overcast"). */
   condition: string;
+  /** Longer human-readable weather description. */
   description: string;
 }
 
+/**
+ * The user's selected weather preferences, one coarse bucket per axis.
+ * An empty string means "no preference" and is treated as a pass-through (no filtering on that axis).
+ */
 export interface WeatherFilters {
+  /** Temperature bucket, or `''` for no temperature constraint. */
   temperature?: 'cold' | 'mild' | 'hot' | '';
+  /** Precipitation bucket, or `''` for no precipitation constraint. */
   precipitation?: 'none' | 'light' | 'heavy' | '';
+  /** Wind bucket, or `''` for no wind constraint. */
   wind?: 'calm' | 'breezy' | 'windy' | '';
 }
 
+/** Map of filter-option key → number of locations that would match it, used for UI badge counts. */
 export interface FilterCounts {
   [key: string]: number;
 }
 
+/** Absolute temperature cut points (°F) derived from the current dataset via {@link WEATHER_PERCENTILES}. */
 export interface WeatherThresholds {
+  /** Upper bound for the "cold" bucket. */
   cold: number;
+  /** Lower bound for the "hot" bucket. */
   hot: number;
+  /** Lower bound of the "mild" band. */
   mildMin: number;
+  /** Upper bound of the "mild" band. */
   mildMax: number;
 }
 
+/** Absolute precipitation cut points (% chance) derived from the current dataset. */
 export interface PrecipitationThresholds {
+  /** Upper bound for the "dry"/none bucket. */
   dry: number;
+  /** Lower bound of the "light" precipitation band. */
   lightMin: number;
+  /** Upper bound of the "light" precipitation band. */
   lightMax: number;
+  /** Lower bound for the "heavy" precipitation bucket. */
   heavy: number;
 }
 
+/** Absolute wind cut points (mph) derived from the current dataset. */
 export interface WindThresholds {
+  /** Upper bound for the "calm" bucket. */
   calm: number;
+  /** Lower bound of the "breezy" band. */
   breezyMin: number;
+  /** Upper bound of the "breezy" band. */
   breezyMax: number;
+  /** Lower bound for the "windy" bucket. */
   windy: number;
 }
 


### PR DESCRIPTION
## Summary

Comment-only documentation pass driven by the **/code-readability** skill, targeting the weakest remaining doc-coverage area after components/hooks/services reached ~100% in #314/#316.

The assessment scored every area of `apps/web/src`; `utils/` was the clear gap (117 exported symbols, **73% TSDoc**, no `@example`s). This PR brings `utils/`, `types/`, and `config/` up to the skill's TSDoc-native standard.

## Coverage scorecard (apps/web/src)

| Area | TSDoc % before → after | File-header % before → after |
|------|:----------------------:|:----------------------------:|
| utils | 73% → **100%** | 92% → **100%** |
| types | 100% (members) → **100%** | 0% → **100%** |
| config | 100% → **100%** | 100% (added per-member docs on `PerformanceMetric`) |

Components / hooks / services were intentionally **not** touched (already done in #314/#316).

## What changed (13 files, comment-only)

- `utils/weatherFilteringUtils.ts`, `poiNavigationUtils.ts`, `locationEstimationUtils.ts`, `locationUtils.ts`, `mapViewCalculations.ts` — TSDoc summaries on exported types, interfaces, and tuning constants (with per-member field docs).
- `utils/adUtils.ts`, `loadAnalytics.ts`, `mapIcons.ts`, `validation.ts`, `contextualWeatherIntelligence.ts` — module headers, `@example`/`@remarks`, and public-API docs. Noted that `ContextualWeatherIntelligence` is a standalone engine not currently wired into the app.
- `types/feedback.ts`, `types/weather.ts` — module headers + per-member field docs.
- `config/performanceRequirements.ts` — per-member docs on `PerformanceMetric`.

## Safety

- **Comment-only.** No logic, identifier, JSX, or runtime changes.
- Proof: `git diff origin/main -G'^[^/ *]'` is **empty** (no non-comment lines changed).
- `npm run lint:web` ✅ clean · `npm run type-check` ✅ clean.
- Verified the docs regenerate correctly: TypeDoc produces 149 reference pages whose summaries/`@example`/per-member text are sourced verbatim from this TSDoc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)