### PR TITLE
ci(steward): skip quality-steward on Dependabot PRs

### DIFF
--- a/.github/workflows/quality-steward.yml
+++ b/.github/workflows/quality-steward.yml
@@ -70,7 +70,10 @@ jobs:
           claude_args: '--max-turns 1'
 
   steward:
-    if: github.event_name != 'workflow_dispatch' || inputs.mode == 'steward'
+    # Skip on Dependabot PRs: the Claude action rejects bot actors, which
+    # otherwise shows up as a spurious failing "steward" check on every dep
+    # bump. Routine dependency PRs don't need an AI review pass anyway.
+    if: (github.event_name != 'workflow_dispatch' || inputs.mode == 'steward') && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }} # available to the agent's Bash for gh + doc git pushes


### PR DESCRIPTION
Gates the `steward` job on `github.actor != 'dependabot[bot]'` so it cleanly skips Dependabot PRs.

**Why:** the Claude action rejects bot actors, so the steward job failed on every Dependabot PR and showed up as a spurious failing `steward` check (seen across this session's dependency PRs). Routine dep bumps don't need an AI review pass, so skipping also avoids wasted API budget.

One-line conditional change; YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)