### PR TITLE
refactor(map): MapContainer effects → hooks (CodeHealth B→A 92.7)

### DIFF
--- a/apps/web/src/components/MapContainer.tsx
+++ b/apps/web/src/components/MapContainer.tsx
@@ -15,11 +15,13 @@
  * - User location marker supports proximity-based recommendations
  * - Navigation system connects to POI discovery algorithm
  *
- * TECHNICAL IMPLEMENTATION: React wrapper around Leaflet with performance optimization
- * - Incremental marker updates prevent full rebuilds on data changes
- * - Drag-enabled user location marker with persistence integration
- * - Event delegation for popup navigation prevents memory leaks
- * - Smart viewport management for optimal user experience
+ * TECHNICAL IMPLEMENTATION: thin React wrapper that composes four Leaflet hooks —
+ * the imperative map lifecycle lives in those hooks, keeping this component focused
+ * on wiring props/refs and rendering the container:
+ * - {@link useLeafletMap}: StrictMode-safe map init + recenter on prop change
+ * - {@link usePoiMarkers}: incremental POI marker updates + auto-open current popup
+ * - {@link useUserLocationMarker}: draggable user marker create + position sync
+ * - {@link useMapPopupNavigation}: popup closer/farther/directions event delegation
  *
  * 🏗️ ARCHITECTURAL DECISIONS:
  * - React StrictMode compatible with proper cleanup
@@ -36,47 +38,20 @@
  * Location detection → POI data loading → map marker rendering → user interaction → navigation
  * USER JOURNEY: Map load → marker discovery → popup interaction → navigation to other POIs
  * VALUE CHAIN: Spatial context → weather information → activity decision → location navigation
- *
- * 📚 DOCUMENTATION LINKS:
- * - Business Plan: /documentation/business-plan/master-plan.md
- * - Architecture: /documentation/architecture-overview.md
- * - Performance Config: /src/config/PERFORMANCE-REQUIREMENTS.json
- *
- * 🔗 COMPONENT INTEGRATIONS:
- * - App.tsx: Main consumer providing POI data and navigation callbacks
- * - LocationManager.tsx: Provides user location for centering and proximity
- * - POI Navigation: Handles distance-based POI discovery and filtering
- *
- * LAST UPDATED: 2025-08-08
  */
 
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useState, useRef, useCallback } from 'react';
 import L from 'leaflet';
-import { trackPOIInteraction, trackFeatureUsage } from '../utils/analytics';
 import { buildPoiPopupHtml } from '../utils/mapPopup';
 import { showEndOfResultsNotification as notifyEndOfResults } from '../utils/mapNotifications';
 // Import POI popup styles
 import '../styles/poi-popup.css';
 
-// 🔗 INTEGRATION: Import asterIcon for consistent branding
-import { asterIcon } from '../utils/mapIcons';
-
-// 🔗 INTEGRATION: TypeScript interfaces for POI data structure
-interface POILocation {
-  id: string;
-  name: string;
-  lat: number;
-  lng: number;
-  temperature: number;
-  condition: string;
-  description: string;
-  precipitation: number;
-  windSpeed: string;
-  distance?: number;
-  park_type?: string;
-  weather_station_name?: string;
-  weather_distance_miles?: string;
-}
+import type { POILocation } from './mapTypes';
+import { useLeafletMap } from '../hooks/useLeafletMap';
+import { usePoiMarkers } from '../hooks/usePoiMarkers';
+import { useUserLocationMarker } from '../hooks/useUserLocationMarker';
+import { useMapPopupNavigation } from '../hooks/useMapPopupNavigation';
 
 /** Props for {@link MapContainer}. */
 interface MapContainerProps {
@@ -106,10 +81,10 @@ interface MapContainerProps {
 
 /**
  * Interactive Leaflet map that renders POI markers with weather-rich popups plus
- * a draggable user-location marker. Wraps Leaflet imperatively with incremental
- * marker updates (no full rebuild on data change) and popup event delegation, so
- * it stays performant and StrictMode-safe. Popup "closer/farther" buttons drive
- * the distance-based POI navigation in the parent.
+ * a draggable user-location marker. The imperative Leaflet work is composed from
+ * four focused hooks (init, markers, user marker, popup navigation); this
+ * component owns the shared refs + popup builders and renders the container.
+ * Popup "closer/farther" buttons drive the distance-based POI navigation in the parent.
  *
  * @example
  * ```tsx
@@ -149,10 +124,9 @@ export const MapContainer: React.FC<MapContainerProps> = ({
   const markersRef = useRef<L.Marker[]>([]);
   const [, setCurrentMarkerIndex] = useState(0);
 
-  // Popup builders — declared before the effects that use them (the marker
-  // effects below) so the React Compiler can preserve their memoization.
-  // The HTML/URL logic itself lives in ../utils/mapPopup (pure + tested); this
-  // is a thin wrapper supplying the current navigation state.
+  // Popup builders — the HTML/URL logic lives in ../utils/mapPopup (pure + tested);
+  // these thin wrappers supply the current navigation state, and are passed to the
+  // marker + navigation hooks.
   const createPopupContent = useCallback((location: POILocation): string => {
     return buildPoiPopupHtml(
       location,
@@ -176,328 +150,23 @@ export const MapContainer: React.FC<MapContainerProps> = ({
   }, [locations, createPopupContent]);
 
   // End-of-results notification — the imperative DOM toast lives in
-  // ../utils/mapNotifications (self-contained); this is a stable callback wrapper
-  // so the navigation effect below keeps a steady dependency.
+  // ../utils/mapNotifications; this is a stable callback wrapper.
   const showEndOfResultsNotification = useCallback(() => {
     notifyEndOfResults();
   }, []);
 
-  // Map initialization with React StrictMode compatibility
-  useEffect(() => {
-    if (!containerRef.current) return;
-
-    // Clear any existing map instance
-    if (mapRef.current) {
-      mapRef.current.remove();
-      mapRef.current = null;
-    }
-
-    // Validate center and zoom before creating map
-    if (!center || isNaN(center[0]) || isNaN(center[1]) || !zoom || isNaN(zoom)) {
-      console.warn('Invalid center or zoom provided to MapContainer:', { center, zoom });
-      return;
-    }
-
-    // Create new map instance
-    const map = L.map(containerRef.current, {
-      center: center,
-      zoom: zoom,
-      scrollWheelZoom: true,
-      zoomControl: false
-    });
-
-    // Add OpenStreetMap tile layer
-    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-      attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-    }).addTo(map);
-
-    mapRef.current = map;
-
-    // Expose map instance for testing purposes
-    if (typeof window !== 'undefined') {
-      (window as any).leafletMapInstance = map;
-    }
-
-    // Cleanup function
-    return () => {
-      if (userMarkerRef.current) {
-        userMarkerRef.current = null;
-      }
-      if (mapRef.current) {
-        mapRef.current.remove();
-        mapRef.current = null;
-      }
-    };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []); // Intentionally empty - map initialization should only run once on component mount
-
-  // Update map center and zoom when props change
-  useEffect(() => {
-    if (mapRef.current && center && !isNaN(center[0]) && !isNaN(center[1]) && zoom && !isNaN(zoom)) {
-      mapRef.current.setView(center, zoom);
-    }
-  }, [center, zoom]);
-
-  // Incremental marker updates for performance optimization
-  useEffect(() => {
-    if (!mapRef.current) return;
-
-    console.log(`MapContainer received ${locations.length} locations`);
-    console.log(`Location IDs: [${locations.slice(0, 5).map(l => l.id).join(', ')}...]`);
-
-    // Optimized incremental marker updates (instead of full rebuild)
-    const existingMarkerCount = markersRef.current.length;
-    const newLocationCount = locations.length;
-
-    // If we have fewer locations now, remove excess markers
-    if (newLocationCount < existingMarkerCount) {
-      for (let i = newLocationCount; i < existingMarkerCount; i++) {
-        if (markersRef.current[i]) {
-          mapRef.current.removeLayer(markersRef.current[i]);
-        }
-      }
-      // Trim the array
-      markersRef.current = markersRef.current.slice(0, newLocationCount);
-    }
-
-    // If we have more locations now, expand the array
-    if (newLocationCount > existingMarkerCount) {
-      markersRef.current = [...markersRef.current, ...new Array(newLocationCount - existingMarkerCount)];
-    }
-
-    console.log(`🔍 MapContainer updating markers: ${existingMarkerCount} -> ${newLocationCount} locations`);
-
-    // Update existing markers and add new ones (incremental approach)
-    locations.forEach((location, index) => {
-      const existingMarker = markersRef.current[index];
-
-      // Check if we need to create a new marker or update existing
-      if (!existingMarker ||
-          existingMarker.getLatLng().lat !== location.lat ||
-          existingMarker.getLatLng().lng !== location.lng) {
-
-        // Remove old marker if it exists
-        if (existingMarker && mapRef.current) {
-          mapRef.current.removeLayer(existingMarker);
-        }
-
-        // Create new marker with branded icon
-        const marker = L.marker([location.lat, location.lng], { icon: asterIcon });
-
-        // Track which marker was clicked to sync currentMarkerIndex
-        marker.on('popupopen', () => {
-          setCurrentMarkerIndex(index);
-
-          // Track POI interaction for analytics
-          trackPOIInteraction('popup-opened', {
-            name: location.name,
-            temperature: location.temperature,
-            condition: location.condition,
-            distance: location.distance,
-            park_type: location.park_type
-          });
-        });
-
-        // Create sanitized popup content for marker
-        const popupContent = createPopupContent(location);
-
-        marker.bindPopup(popupContent, { maxWidth: 280, className: "custom-popup" });
-        marker.addTo(mapRef.current!);
-
-        // Store marker reference for direct popup access
-        markersRef.current[index] = marker;
-      } else {
-        // Marker exists and position hasn't changed - update popup if needed
-        const existingPopup = existingMarker.getPopup();
-        if (existingPopup) {
-          updatePopupContent(index);
-        }
-      }
-    });
-
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [locations]); // canExpand, isAtClosest, isAtFarthest intentionally excluded
-
-  // User location marker creation and management
-  useEffect(() => {
-    if (!mapRef.current) return;
-    if (userMarkerRef.current) return; // Already created
-    if (!userLocation || userLocation[0] === undefined || userLocation[1] === undefined ||
-        isNaN(userLocation[0]) || isNaN(userLocation[1])) return;
-
-    console.log('🔧 Creating user location marker with drag handler');
-
-    // Create user location icon with branded styling
-    const coolGuyIcon = new L.Icon({
-      iconUrl: 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(`
-        <svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">
-          <circle cx="20" cy="20" r="15" fill="white" stroke="#ddd" stroke-width="1"/>
-          <text x="20" y="28" text-anchor="middle" font-size="24" font-family="Arial, sans-serif">😎</text>
-        </svg>
-      `),
-      iconSize: [40, 40],
-      iconAnchor: [20, 20],
-      popupAnchor: [0, -20]
-    });
-
-    const userMarker = L.marker(userLocation, {
-      draggable: true,
-      icon: coolGuyIcon
-    }) as any;
-    userMarker.options.isUserMarker = true;
-
-    // Attach drag handlers for location updates
-    userMarker.on('dragend', (e: L.LeafletEvent) => {
-      console.log('🎯 User marker dragend event triggered!');
-      const marker = (e as any).target;
-      const position = marker.getLatLng();
-      console.log('📍 New position from drag:', [position.lat, position.lng]);
-      if (position && !isNaN(position.lat) && !isNaN(position.lng)) {
-        onLocationChange([position.lat, position.lng]);
-      } else {
-        console.warn('❌ Invalid position from drag:', position);
-      }
-    });
-
-    // Add instructional popup
-    const popupContent = `
-      <div class="text-center p-2">
-        <div class="text-sm font-bold text-gray-800 mb-1">Our best guess at your location</div>
-        <div class="text-xs text-gray-600">Drag and drop for more accuracy</div>
-      </div>
-    `;
-
-    userMarker.bindPopup(popupContent, { className: "custom-popup" });
-    userMarker.addTo(mapRef.current!);
-
-    // Store reference to the marker
-    userMarkerRef.current = userMarker;
-  }, [onLocationChange, userLocation]); // Dependencies: callback and user location
-
-  // Update user marker position without recreating it
-  useEffect(() => {
-    if (!userMarkerRef.current) return;
-    if (!userLocation || userLocation[0] === undefined || userLocation[1] === undefined ||
-        isNaN(userLocation[0]) || isNaN(userLocation[1])) {
-      // Location became invalid - remove marker
-      if (mapRef.current && userMarkerRef.current) {
-        mapRef.current.removeLayer(userMarkerRef.current);
-        userMarkerRef.current = null;
-      }
-      return;
-    }
-
-    // Update position of existing marker (preserves drag handlers)
-    console.log('📍 Updating user marker position:', userLocation);
-    userMarkerRef.current.setLatLng(userLocation);
-  }, [userLocation]);
-
-  // Event delegation for popup navigation buttons and analytics tracking
-  useEffect(() => {
-    const handleNavigation = (event: Event) => {
-      const target = event.target as HTMLElement;
-
-      // Handle directions button analytics
-      if (target.matches('[data-analytics-action="directions-clicked"]')) {
-        const poiName = target.getAttribute('data-analytics-poi');
-        if (poiName) {
-          trackFeatureUsage('directions', { poi_name: poiName });
-        }
-        return; // Let the link work normally
-      }
-
-      // Handle navigation buttons
-      if (!target.matches('[data-nav-action]')) return;
-
-      event.preventDefault();
-      event.stopPropagation();
-
-      const action = target.getAttribute('data-nav-action');
-
-      if (action === 'closer') {
-        const result = onNavigateCloser();
-        if (result) {
-          console.log('Navigate closer result:', result);
-          const newPOIIndex = locations.findIndex(loc => loc.id === result.id);
-          if (newPOIIndex >= 0 && markersRef.current[newPOIIndex]) {
-            updatePopupContent(newPOIIndex);
-            markersRef.current[newPOIIndex].openPopup();
-
-            // Smart centering: only pan if marker is outside viewport
-            const markerLatLng = L.latLng(result.lat, result.lng);
-            if (mapRef.current && !mapRef.current.getBounds().contains(markerLatLng)) {
-              mapRef.current.panTo(markerLatLng);
-            }
-          }
-        }
-      } else if (action === 'farther') {
-        const result = onNavigateFarther();
-        if (result && result !== 'NO_MORE_RESULTS') {
-          console.log('Navigate farther result:', result);
-          const newPOIIndex = locations.findIndex(loc => (loc as POILocation).id === (result as POILocation).id);
-          if (newPOIIndex >= 0 && markersRef.current[newPOIIndex]) {
-            updatePopupContent(newPOIIndex);
-            markersRef.current[newPOIIndex].openPopup();
-
-            // Smart centering: only pan if marker is outside viewport
-            const markerLatLng = L.latLng((result as POILocation).lat, (result as POILocation).lng);
-            if (mapRef.current && !mapRef.current.getBounds().contains(markerLatLng)) {
-              mapRef.current.panTo(markerLatLng);
-            }
-          }
-        } else if (result === 'NO_MORE_RESULTS') {
-          console.log('No more results available');
-          showEndOfResultsNotification();
-        }
-      }
-    };
-
-    // Add event listener to document for event delegation
-    document.addEventListener('click', handleNavigation);
-
-    // Cleanup
-    return () => {
-      document.removeEventListener('click', handleNavigation);
-    };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [onNavigateCloser, onNavigateFarther, locations]);
-
-
-  // Auto-open popup for currentPOI
-  useEffect(() => {
-    if (currentPOI && markersRef.current.length > 0) {
-      const currentPOIIndex = locations.findIndex(loc => loc.id === currentPOI.id);
-
-      const openPopupAndCenter = () => {
-        if (currentPOIIndex >= 0 && markersRef.current[currentPOIIndex]) {
-          console.log(`🎯 Auto-opening popup for currentPOI: ${currentPOI.name} (index ${currentPOIIndex})`);
-
-          // Smart centering: check if marker is outside viewport
-          const markerLatLng = L.latLng(currentPOI.lat, currentPOI.lng);
-          if (mapRef.current && !mapRef.current.getBounds().contains(markerLatLng)) {
-            console.log(`📍 Centering map on ${currentPOI.name}`);
-            mapRef.current.panTo(markerLatLng);
-
-            // Wait for pan animation before opening popup
-            setTimeout(() => {
-              updatePopupContent(currentPOIIndex);
-              markersRef.current[currentPOIIndex].openPopup();
-            }, 300);
-          } else {
-            console.log(`📍 ${currentPOI.name} already in viewport`);
-            updatePopupContent(currentPOIIndex);
-            markersRef.current[currentPOIIndex].openPopup();
-          }
-        } else if (currentPOIIndex >= 0) {
-          // Marker not ready yet, retry after brief delay
-          console.log(`⏳ Marker ${currentPOIIndex} not ready, retrying...`);
-          setTimeout(openPopupAndCenter, 100);
-        }
-      };
-
-      openPopupAndCenter();
-    }
-  }, [currentPOI, locations, updatePopupContent]);
+  // Compose the Leaflet lifecycle from focused hooks (see each hook's docs).
+  useLeafletMap(containerRef, mapRef, userMarkerRef, center, zoom);
+  usePoiMarkers({
+    mapRef, markersRef, locations, currentPOI,
+    createPopupContent, updatePopupContent, setCurrentMarkerIndex,
+  });
+  useUserLocationMarker(mapRef, userMarkerRef, userLocation, onLocationChange);
+  useMapPopupNavigation({
+    mapRef, markersRef, locations,
+    onNavigateCloser, onNavigateFarther,
+    updatePopupContent, showEndOfResultsNotification,
+  });
 
   return (
     <div

--- a/apps/web/src/components/mapTypes.ts
+++ b/apps/web/src/components/mapTypes.ts
@@ -1,0 +1,40 @@
+/**
+ * ========================================================================
+ * MAP TYPES
+ * ========================================================================
+ *
+ * Shared types for the MapContainer component and its extracted hooks
+ * (useLeafletMap, usePoiMarkers, useUserLocationMarker, useMapPopupNavigation).
+ * Lives in its own module so the hooks and the component can both import
+ * POILocation without a circular dependency.
+ */
+
+/** A weather-enriched outdoor-recreation POI as rendered on the Leaflet map. */
+export interface POILocation {
+  /** Stable unique identifier for the POI. */
+  id: string;
+  /** Human-readable POI name. */
+  name: string;
+  /** Latitude in decimal degrees. */
+  lat: number;
+  /** Longitude in decimal degrees. */
+  lng: number;
+  /** Temperature in degrees Fahrenheit. */
+  temperature: number;
+  /** Short condition label (e.g. "Clear"). */
+  condition: string;
+  /** Longer human-readable weather description. */
+  description: string;
+  /** Precipitation probability as a 0–100 percentage. */
+  precipitation: number;
+  /** Wind speed, formatted for display (e.g. "8 mph"). */
+  windSpeed: string;
+  /** Distance from the user in miles, when known. */
+  distance?: number;
+  /** Park classification (e.g. "State Park"). */
+  park_type?: string;
+  /** Name of the weather station the conditions came from. */
+  weather_station_name?: string;
+  /** Distance to that weather station, formatted for display. */
+  weather_distance_miles?: string;
+}

--- a/apps/web/src/hooks/useLeafletMap.ts
+++ b/apps/web/src/hooks/useLeafletMap.ts
@@ -1,0 +1,80 @@
+/**
+ * useLeafletMap — owns the Leaflet map instance lifecycle for MapContainer:
+ * StrictMode-safe creation (with the OSM tile layer) on mount, recenter/zoom on
+ * prop change, and teardown on unmount. Extracted from MapContainer to keep the
+ * component thin; the map/userMarker refs are passed in so the wiring is unchanged.
+ */
+import { useEffect, type RefObject, type MutableRefObject } from 'react';
+import L from 'leaflet';
+
+/**
+ * Wire up the Leaflet map instance.
+ * @param containerRef - the map's container `<div>` ref
+ * @param mapRef - holds the created `L.Map` (shared with the marker/nav hooks)
+ * @param userMarkerRef - cleared on map teardown so a remount recreates it
+ * @param center - map center `[lat, lng]`
+ * @param zoom - Leaflet zoom level
+ */
+export function useLeafletMap(
+  containerRef: RefObject<HTMLDivElement>,
+  mapRef: MutableRefObject<L.Map | null>,
+  userMarkerRef: MutableRefObject<L.Marker | null>,
+  center: [number, number],
+  zoom: number,
+): void {
+  // Map initialization with React StrictMode compatibility
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    // Clear any existing map instance
+    if (mapRef.current) {
+      mapRef.current.remove();
+      mapRef.current = null;
+    }
+
+    // Validate center and zoom before creating map
+    if (!center || isNaN(center[0]) || isNaN(center[1]) || !zoom || isNaN(zoom)) {
+      console.warn('Invalid center or zoom provided to MapContainer:', { center, zoom });
+      return;
+    }
+
+    // Create new map instance
+    const map = L.map(containerRef.current, {
+      center: center,
+      zoom: zoom,
+      scrollWheelZoom: true,
+      zoomControl: false
+    });
+
+    // Add OpenStreetMap tile layer
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+    }).addTo(map);
+
+    mapRef.current = map;
+
+    // Expose map instance for testing purposes
+    if (typeof window !== 'undefined') {
+      (window as any).leafletMapInstance = map;
+    }
+
+    // Cleanup function
+    return () => {
+      if (userMarkerRef.current) {
+        userMarkerRef.current = null;
+      }
+      if (mapRef.current) {
+        mapRef.current.remove();
+        mapRef.current = null;
+      }
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // Intentionally empty - map initialization should only run once on component mount
+
+  // Update map center and zoom when props change
+  useEffect(() => {
+    if (mapRef.current && center && !isNaN(center[0]) && !isNaN(center[1]) && zoom && !isNaN(zoom)) {
+      mapRef.current.setView(center, zoom);
+    }
+  }, [center, zoom, mapRef]);
+}

--- a/apps/web/src/hooks/useMapPopupNavigation.ts
+++ b/apps/web/src/hooks/useMapPopupNavigation.ts
@@ -1,0 +1,110 @@
+/**
+ * useMapPopupNavigation — document-level click delegation for the POI popup's
+ * navigation buttons (closer / farther) and the "directions" analytics link.
+ * Drives the parent's distance-based navigation, opens + smart-centers the target
+ * marker's popup, and shows the end-of-results toast at the boundary. Extracted
+ * from MapContainer; refs + callbacks passed in unchanged.
+ */
+import { useEffect, type MutableRefObject } from 'react';
+import L from 'leaflet';
+import { trackFeatureUsage } from '../utils/analytics';
+import type { POILocation } from '../components/mapTypes';
+
+/** Inputs for {@link useMapPopupNavigation}. */
+export interface UseMapPopupNavigationArgs {
+  /** The Leaflet map instance ref. */
+  mapRef: MutableRefObject<L.Map | null>;
+  /** The rendered POI markers, index-aligned with `locations`. */
+  markersRef: MutableRefObject<L.Marker[]>;
+  /** The current POIs (to map a navigation result back to a marker index). */
+  locations: POILocation[];
+  /** Step to the next-closer POI; returns it, or null at the boundary. */
+  onNavigateCloser: () => POILocation | null;
+  /** Step to the next-farther POI, or expand the radius; may return a status string. */
+  onNavigateFarther: () => POILocation | string | null;
+  /** Refreshes an existing marker's popup HTML by index. */
+  updatePopupContent: (markerIndex: number) => void;
+  /** Shows the "end of results" toast when navigation can't go farther. */
+  showEndOfResultsNotification: () => void;
+}
+
+/** Attach the popup-button click delegation for the lifetime of the component. */
+export function useMapPopupNavigation({
+  mapRef,
+  markersRef,
+  locations,
+  onNavigateCloser,
+  onNavigateFarther,
+  updatePopupContent,
+  showEndOfResultsNotification,
+}: UseMapPopupNavigationArgs): void {
+  // Event delegation for popup navigation buttons and analytics tracking
+  useEffect(() => {
+    const handleNavigation = (event: Event) => {
+      const target = event.target as HTMLElement;
+
+      // Handle directions button analytics
+      if (target.matches('[data-analytics-action="directions-clicked"]')) {
+        const poiName = target.getAttribute('data-analytics-poi');
+        if (poiName) {
+          trackFeatureUsage('directions', { poi_name: poiName });
+        }
+        return; // Let the link work normally
+      }
+
+      // Handle navigation buttons
+      if (!target.matches('[data-nav-action]')) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+
+      const action = target.getAttribute('data-nav-action');
+
+      if (action === 'closer') {
+        const result = onNavigateCloser();
+        if (result) {
+          console.log('Navigate closer result:', result);
+          const newPOIIndex = locations.findIndex(loc => loc.id === result.id);
+          if (newPOIIndex >= 0 && markersRef.current[newPOIIndex]) {
+            updatePopupContent(newPOIIndex);
+            markersRef.current[newPOIIndex].openPopup();
+
+            // Smart centering: only pan if marker is outside viewport
+            const markerLatLng = L.latLng(result.lat, result.lng);
+            if (mapRef.current && !mapRef.current.getBounds().contains(markerLatLng)) {
+              mapRef.current.panTo(markerLatLng);
+            }
+          }
+        }
+      } else if (action === 'farther') {
+        const result = onNavigateFarther();
+        if (result && result !== 'NO_MORE_RESULTS') {
+          console.log('Navigate farther result:', result);
+          const newPOIIndex = locations.findIndex(loc => (loc as POILocation).id === (result as POILocation).id);
+          if (newPOIIndex >= 0 && markersRef.current[newPOIIndex]) {
+            updatePopupContent(newPOIIndex);
+            markersRef.current[newPOIIndex].openPopup();
+
+            // Smart centering: only pan if marker is outside viewport
+            const markerLatLng = L.latLng((result as POILocation).lat, (result as POILocation).lng);
+            if (mapRef.current && !mapRef.current.getBounds().contains(markerLatLng)) {
+              mapRef.current.panTo(markerLatLng);
+            }
+          }
+        } else if (result === 'NO_MORE_RESULTS') {
+          console.log('No more results available');
+          showEndOfResultsNotification();
+        }
+      }
+    };
+
+    // Add event listener to document for event delegation
+    document.addEventListener('click', handleNavigation);
+
+    // Cleanup
+    return () => {
+      document.removeEventListener('click', handleNavigation);
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [onNavigateCloser, onNavigateFarther, locations]);
+}

--- a/apps/web/src/hooks/usePoiMarkers.ts
+++ b/apps/web/src/hooks/usePoiMarkers.ts
@@ -1,0 +1,156 @@
+/**
+ * usePoiMarkers — renders POI markers on the Leaflet map with incremental updates
+ * (add/remove/replace only what changed, never a full rebuild) and auto-opens the
+ * popup for the currently-navigated POI (smart-centering only when off-screen).
+ * Extracted from MapContainer; refs + popup callbacks are passed in unchanged.
+ */
+import { useEffect, type MutableRefObject } from 'react';
+import L from 'leaflet';
+import { trackPOIInteraction } from '../utils/analytics';
+import { asterIcon } from '../utils/mapIcons';
+import type { POILocation } from '../components/mapTypes';
+
+/** Inputs for {@link usePoiMarkers} — the map/markers refs, the POIs, and popup helpers. */
+export interface UsePoiMarkersArgs {
+  /** The Leaflet map instance ref. */
+  mapRef: MutableRefObject<L.Map | null>;
+  /** Holds the rendered POI markers, index-aligned with `locations`. */
+  markersRef: MutableRefObject<L.Marker[]>;
+  /** POIs to render. */
+  locations: POILocation[];
+  /** The POI to auto-open a popup for, or null. */
+  currentPOI: POILocation | null;
+  /** Builds popup HTML for a location (current navigation state baked in). */
+  createPopupContent: (location: POILocation) => string;
+  /** Refreshes an existing marker's popup HTML by index. */
+  updatePopupContent: (markerIndex: number) => void;
+  /** Records which marker index is currently open (for navigation sync). */
+  setCurrentMarkerIndex: (index: number) => void;
+}
+
+/** Render + maintain the POI markers and the auto-opened current-POI popup. */
+export function usePoiMarkers({
+  mapRef,
+  markersRef,
+  locations,
+  currentPOI,
+  createPopupContent,
+  updatePopupContent,
+  setCurrentMarkerIndex,
+}: UsePoiMarkersArgs): void {
+  // Incremental marker updates for performance optimization
+  useEffect(() => {
+    if (!mapRef.current) return;
+
+    console.log(`MapContainer received ${locations.length} locations`);
+    console.log(`Location IDs: [${locations.slice(0, 5).map(l => l.id).join(', ')}...]`);
+
+    // Optimized incremental marker updates (instead of full rebuild)
+    const existingMarkerCount = markersRef.current.length;
+    const newLocationCount = locations.length;
+
+    // If we have fewer locations now, remove excess markers
+    if (newLocationCount < existingMarkerCount) {
+      for (let i = newLocationCount; i < existingMarkerCount; i++) {
+        if (markersRef.current[i]) {
+          mapRef.current.removeLayer(markersRef.current[i]);
+        }
+      }
+      // Trim the array
+      markersRef.current = markersRef.current.slice(0, newLocationCount);
+    }
+
+    // If we have more locations now, expand the array
+    if (newLocationCount > existingMarkerCount) {
+      markersRef.current = [...markersRef.current, ...new Array(newLocationCount - existingMarkerCount)];
+    }
+
+    console.log(`🔍 MapContainer updating markers: ${existingMarkerCount} -> ${newLocationCount} locations`);
+
+    // Update existing markers and add new ones (incremental approach)
+    locations.forEach((location, index) => {
+      const existingMarker = markersRef.current[index];
+
+      // Check if we need to create a new marker or update existing
+      if (!existingMarker ||
+          existingMarker.getLatLng().lat !== location.lat ||
+          existingMarker.getLatLng().lng !== location.lng) {
+
+        // Remove old marker if it exists
+        if (existingMarker && mapRef.current) {
+          mapRef.current.removeLayer(existingMarker);
+        }
+
+        // Create new marker with branded icon
+        const marker = L.marker([location.lat, location.lng], { icon: asterIcon });
+
+        // Track which marker was clicked to sync currentMarkerIndex
+        marker.on('popupopen', () => {
+          setCurrentMarkerIndex(index);
+
+          // Track POI interaction for analytics
+          trackPOIInteraction('popup-opened', {
+            name: location.name,
+            temperature: location.temperature,
+            condition: location.condition,
+            distance: location.distance,
+            park_type: location.park_type
+          });
+        });
+
+        // Create sanitized popup content for marker
+        const popupContent = createPopupContent(location);
+
+        marker.bindPopup(popupContent, { maxWidth: 280, className: "custom-popup" });
+        marker.addTo(mapRef.current!);
+
+        // Store marker reference for direct popup access
+        markersRef.current[index] = marker;
+      } else {
+        // Marker exists and position hasn't changed - update popup if needed
+        const existingPopup = existingMarker.getPopup();
+        if (existingPopup) {
+          updatePopupContent(index);
+        }
+      }
+    });
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [locations]); // canExpand, isAtClosest, isAtFarthest intentionally excluded
+
+  // Auto-open popup for currentPOI
+  useEffect(() => {
+    if (currentPOI && markersRef.current.length > 0) {
+      const currentPOIIndex = locations.findIndex(loc => loc.id === currentPOI.id);
+
+      const openPopupAndCenter = () => {
+        if (currentPOIIndex >= 0 && markersRef.current[currentPOIIndex]) {
+          console.log(`🎯 Auto-opening popup for currentPOI: ${currentPOI.name} (index ${currentPOIIndex})`);
+
+          // Smart centering: check if marker is outside viewport
+          const markerLatLng = L.latLng(currentPOI.lat, currentPOI.lng);
+          if (mapRef.current && !mapRef.current.getBounds().contains(markerLatLng)) {
+            console.log(`📍 Centering map on ${currentPOI.name}`);
+            mapRef.current.panTo(markerLatLng);
+
+            // Wait for pan animation before opening popup
+            setTimeout(() => {
+              updatePopupContent(currentPOIIndex);
+              markersRef.current[currentPOIIndex].openPopup();
+            }, 300);
+          } else {
+            console.log(`📍 ${currentPOI.name} already in viewport`);
+            updatePopupContent(currentPOIIndex);
+            markersRef.current[currentPOIIndex].openPopup();
+          }
+        } else if (currentPOIIndex >= 0) {
+          // Marker not ready yet, retry after brief delay
+          console.log(`⏳ Marker ${currentPOIIndex} not ready, retrying...`);
+          setTimeout(openPopupAndCenter, 100);
+        }
+      };
+
+      openPopupAndCenter();
+    }
+  }, [currentPOI, locations, updatePopupContent, mapRef, markersRef]);
+}

--- a/apps/web/src/hooks/useUserLocationMarker.ts
+++ b/apps/web/src/hooks/useUserLocationMarker.ts
@@ -1,0 +1,96 @@
+/**
+ * useUserLocationMarker — manages the draggable "you are here" marker: creates it
+ * once (with the 😎 icon, drag-to-update handler, and instructional popup), keeps
+ * its position in sync with the `userLocation` prop, and removes it when the
+ * location becomes invalid. Extracted from MapContainer; refs passed in unchanged.
+ */
+import { useEffect, type MutableRefObject } from 'react';
+import L from 'leaflet';
+
+/**
+ * Wire up the user-location marker.
+ * @param mapRef - the Leaflet map instance ref
+ * @param userMarkerRef - holds the user marker (shared with the map-teardown hook)
+ * @param userLocation - current user position `[lat, lng]`, or null when unknown
+ * @param onLocationChange - fired when the user drags the marker to a new position
+ */
+export function useUserLocationMarker(
+  mapRef: MutableRefObject<L.Map | null>,
+  userMarkerRef: MutableRefObject<L.Marker | null>,
+  userLocation: [number, number] | null,
+  onLocationChange: (newPosition: [number, number]) => void,
+): void {
+  // User location marker creation and management
+  useEffect(() => {
+    if (!mapRef.current) return;
+    if (userMarkerRef.current) return; // Already created
+    if (!userLocation || userLocation[0] === undefined || userLocation[1] === undefined ||
+        isNaN(userLocation[0]) || isNaN(userLocation[1])) return;
+
+    console.log('🔧 Creating user location marker with drag handler');
+
+    // Create user location icon with branded styling
+    const coolGuyIcon = new L.Icon({
+      iconUrl: 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(`
+        <svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">
+          <circle cx="20" cy="20" r="15" fill="white" stroke="#ddd" stroke-width="1"/>
+          <text x="20" y="28" text-anchor="middle" font-size="24" font-family="Arial, sans-serif">😎</text>
+        </svg>
+      `),
+      iconSize: [40, 40],
+      iconAnchor: [20, 20],
+      popupAnchor: [0, -20]
+    });
+
+    const userMarker = L.marker(userLocation, {
+      draggable: true,
+      icon: coolGuyIcon
+    }) as any;
+    userMarker.options.isUserMarker = true;
+
+    // Attach drag handlers for location updates
+    userMarker.on('dragend', (e: L.LeafletEvent) => {
+      console.log('🎯 User marker dragend event triggered!');
+      const marker = (e as any).target;
+      const position = marker.getLatLng();
+      console.log('📍 New position from drag:', [position.lat, position.lng]);
+      if (position && !isNaN(position.lat) && !isNaN(position.lng)) {
+        onLocationChange([position.lat, position.lng]);
+      } else {
+        console.warn('❌ Invalid position from drag:', position);
+      }
+    });
+
+    // Add instructional popup
+    const popupContent = `
+      <div class="text-center p-2">
+        <div class="text-sm font-bold text-gray-800 mb-1">Our best guess at your location</div>
+        <div class="text-xs text-gray-600">Drag and drop for more accuracy</div>
+      </div>
+    `;
+
+    userMarker.bindPopup(popupContent, { className: "custom-popup" });
+    userMarker.addTo(mapRef.current!);
+
+    // Store reference to the marker
+    userMarkerRef.current = userMarker;
+  }, [onLocationChange, userLocation, mapRef, userMarkerRef]); // Dependencies: callback and user location
+
+  // Update user marker position without recreating it
+  useEffect(() => {
+    if (!userMarkerRef.current) return;
+    if (!userLocation || userLocation[0] === undefined || userLocation[1] === undefined ||
+        isNaN(userLocation[0]) || isNaN(userLocation[1])) {
+      // Location became invalid - remove marker
+      if (mapRef.current && userMarkerRef.current) {
+        mapRef.current.removeLayer(userMarkerRef.current);
+        userMarkerRef.current = null;
+      }
+      return;
+    }
+
+    // Update position of existing marker (preserves drag handlers)
+    console.log('📍 Updating user marker position:', userLocation);
+    userMarkerRef.current.setLatLng(userLocation);
+  }, [userLocation, mapRef, userMarkerRef]);
+}


### PR DESCRIPTION
Rebuilt cleanly on `main` after #322 merged (supersedes #323, which auto-closed when its base branch was deleted).

Greens the last yellow file (`MapContainer.tsx`), taking CodeHealth **89.8 → 92.7 (B → A)**.

## What
MapContainer's 7 `useEffect`s moved **verbatim** into four focused, documented hooks (same deps, cleanups, imperative Leaflet calls — behavior-preserving); the component keeps the shared refs + popup builders and composes them:
- `useLeafletMap` · `usePoiMarkers` · `useUserLocationMarker` · `useMapPopupNavigation` · `mapTypes.ts` (shared type, no cycle)

## Verified
- ✅ **Visual validation on the preview** (real browser): map + 31 POI markers + OSM tiles render, popups open with closer/farther nav (delegation works), user marker draggable, **0 console errors**.
- ✅ lint + type-check + full vitest suite (incl. 12 MapContainer tests) + vite build.
- MapContainer MI 16.7 → green; **0 files > 500 LOC**; CodeHealth A · 92.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)