### PR TITLE
feat(steward): quality-coverage checklist dashboard

### DIFF
--- a/.claude/agents/quality-steward.md
+++ b/.claude/agents/quality-steward.md
@@ -101,6 +101,11 @@ Keep the docs true to the code:
   and stamp the wiki page (`stamp-codehealth.mjs <wiki>/Code-Health-Dashboard.md`) so its
   `<!--ch:*-->` markers reflect the new reading. The dashboard is the single rendering of the
   CodeHealth roll-up.
+- Refresh the **Quality-Coverage checklist** (`npm run quality:checklist -- --wiki <wiki>
+  --stamp <wiki>/Quality-Coverage.md`): it re-probes which quality capabilities are actually
+  enabled vs. available-but-off, so a capability that exists but was never turned on (a metric
+  measured but never made a CI gate) doesn't stay a silent gap. Raise any new ❌ gap as a
+  suggestion in step 2's channel.
 - Run the project's **doc-publish flow** to refresh living docs (e.g. `/code-readability
   publish` / `team`, plus any stamp scripts). Respect generator markers — never clobber
   hand-authored pages.

--- a/.claude/skills/code-health/SKILL.md
+++ b/.claude/skills/code-health/SKILL.md
@@ -108,6 +108,23 @@ headline grade → metrics by **business outcome** (risk / throughput / onboardi
 → detailed views (MI pie, hotspots, coupling) → glossary. Every view ends with
 **Improve & ROI**. Mirror the layout in `references/methodology.md`.
 
+## Quality-coverage checklist (steward feature)
+
+`quality-checklist.mjs` is a steward-level tracker that ships here (it reuses this
+skill's config + the `/wiki-publish` stamper). It probes the repo — CI workflows,
+ESLint config, `package.json`, pre-commit, the code-health history, installed
+skills, and (with `--wiki`) published pages — for **every** capability the quality
+skills offer, and classifies each ✅ enabled / ⚠️ partial / ❌ gap / ➖ n/a. It exists
+to stop audits from forgetting things: a capability that's available but never
+turned on is a silent gap (e.g. a metric *measured* but never made a CI **gate**).
+
+```bash
+node <skill>/scripts/quality-checklist.mjs --wiki <wiki> --stamp <wiki>/Quality-Coverage.md
+```
+
+Writes `<historyDir>/quality-checklist.json` and stamps the `<!--ql:*-->` markers on
+the **Quality-Coverage** dashboard. The steward runs it in its weekly document step.
+
 ## Trend it (optional)
 
 Schedule the steward (or a `maintainability.yml` workflow) weekly to commit the
@@ -128,4 +145,5 @@ an early-warning trend.
 - `scripts/codehealth-report.mjs` — the roll-up + stamp facts
 - `scripts/stamp-codehealth.mjs` — fill dashboard markers
 - `scripts/run-all.mjs` — produce everything in order (+ optional `--stamp`)
+- `scripts/quality-checklist.mjs` — capability-coverage checklist → Quality-Coverage dashboard
 - `references/methodology.md` — formulas, anchors, glossary, dashboard template

--- a/.claude/skills/code-health/scripts/quality-checklist.mjs
+++ b/.claude/skills/code-health/scripts/quality-checklist.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+//
+// Quality-coverage checklist — the steward's "what quality capability is available,
+// and is it actually turned on here?" tracker. Probes the repo (CI workflows, ESLint
+// config, package.json scripts, pre-commit, code-health history, installed skills,
+// and — with --wiki — published wiki pages) for every capability the quality skills
+// offer, classifies each ✅ done / ⚠️ partial / ❌ gap / ➖ n/a, and renders a grouped
+// matrix + summary. Writes facts to <historyDir>/quality-checklist.json and, with
+// --stamp, fills the <!--ql:*--> markers on the Quality-Coverage dashboard. Surfaces
+// the things an audit forgot (e.g. metrics measured but never made CI gates).
+//
+//   node quality-checklist.mjs [--wiki <wiki-dir>] [--stamp <page.md>...]
+//
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execSync } from 'node:child_process';
+import { HISTORY_DIR, today } from './config.mjs';
+
+const argv = process.argv.slice(2);
+const wikiDir = argv.includes('--wiki') ? argv[argv.indexOf('--wiki') + 1] : null;
+const stampIdx = argv.indexOf('--stamp');
+const stampTargets = stampIdx >= 0 ? argv.slice(stampIdx + 1).filter((a) => !a.startsWith('--')) : [];
+
+const read = (p) => { try { return fs.readFileSync(p, 'utf8'); } catch { return ''; } };
+const exists = (p) => fs.existsSync(p);
+function find(globs, roots = ['.', 'apps/web', 'apps/api']) {
+  const out = [];
+  for (const r of roots) for (const g of globs) { const p = path.join(r, g); if (exists(p)) out.push(p); }
+  return out;
+}
+const ci = find(['.github/workflows']).flatMap((d) => exists(d) ? fs.readdirSync(d).map((f) => read(path.join(d, f))) : []).join('\n')
+  || (exists('.github/workflows') ? fs.readdirSync('.github/workflows').map((f) => read(path.join('.github/workflows', f))).join('\n') : '');
+const pkg = (() => { try { return JSON.parse(read('package.json')); } catch { return {}; } })();
+const scripts = pkg.scripts || {};
+const eslintTxt = find(['eslint.config.js', 'eslint.config.mjs', '.eslintrc.js', '.eslintrc.json', '.eslintrc.cjs']).map(read).join('\n');
+const vitestTxt = find(['vitest.config.ts', 'vitest.config.js', 'vite.config.ts']).map(read).join('\n');
+const preCommit = read('.pre-commit-config.yaml') + (exists('.husky') ? fs.readdirSync('.husky').map((f) => read(path.join('.husky', f))).join('\n') : '');
+
+const npmScript = (re) => Object.keys(scripts).some((k) => re.test(k));
+const ciHas = (re) => re.test(ci);
+const usesDrizzle = /drizzle/.test(JSON.stringify(pkg.dependencies || {}) + JSON.stringify(pkg.devDependencies || {}));
+
+// status: 'done' | 'partial' | 'gap' | 'na' | 'manual'
+const DONE = 'done', GAP = 'gap', PARTIAL = 'partial', NA = 'na', MANUAL = 'manual';
+// Wiki-output probes: without --wiki we can't tell (manual check); with it, done/gap.
+const wikiStatus = (name) => wikiDir ? (exists(path.join(wikiDir, `${name}.md`)) ? DONE : GAP) : MANUAL;
+const ICON = { done: '✅', partial: '⚠️', gap: '❌', na: '➖', manual: '🔍' };
+
+const CAPS = [
+  // group, capability, status, detail
+  ['🛡️ Build & test gates (CI)', 'Lint', ciHas(/lint/i) ? DONE : GAP, '`eslint --max-warnings 0`'],
+  ['🛡️ Build & test gates (CI)', 'Type-check', ciHas(/type.?check|tsc/i) ? DONE : GAP, '`tsc --noEmit`'],
+  ['🛡️ Build & test gates (CI)', 'Unit tests', npmScript(/^test/) ? DONE : GAP, 'vitest'],
+  ['🛡️ Build & test gates (CI)', 'Build validation', ciHas(/build/i) ? DONE : GAP, 'vite build'],
+  ['🛡️ Build & test gates (CI)', 'Coverage threshold gate', /thresholds\s*:\s*\{[^}]*\d/.test(vitestTxt) ? DONE : GAP, 'fail CI below a coverage floor'],
+
+  ['🔒 Security', 'Secret scanning', (ciHas(/trufflehog|gitleaks/i) || /gitleaks|detect-secret/i.test(preCommit)) ? DONE : GAP, 'TruffleHog (CI) / gitleaks (pre-commit)'],
+  ['🔒 Security', 'Dependency audit (SCA)', ciHas(/npm audit|security audit/i) ? DONE : GAP, '`npm audit` in CI + code-health trend'],
+  ['🔒 Security', 'SAST (CodeQL)', ciHas(/codeql/i) ? DONE : GAP, 'GitHub CodeQL'],
+  ['🔒 Security', '/security-audit per-PR (semgrep + osv)', ciHas(/security-audit/i) && /run/.test(ci) ? DONE : GAP, 'differential SAST/SCA + LLM verify on the diff'],
+
+  ['📊 Code-health metrics', 'Maintainability Index', npmScript(/^mi:report/) ? DONE : GAP, ''],
+  ['📊 Code-health metrics', 'Cyclomatic complexity', npmScript(/^complexity:report/) ? DONE : GAP, ''],
+  ['📊 Code-health metrics', 'Hotspots (churn × complexity)', npmScript(/^hotspot:report/) ? DONE : GAP, ''],
+  ['📊 Code-health metrics', 'Coupling / instability', npmScript(/^coupling:report/) ? DONE : GAP, ''],
+  ['📊 Code-health metrics', 'Change coupling', npmScript(/^change-coupling:report/) ? DONE : GAP, ''],
+  ['📊 Code-health metrics', 'Duplication', npmScript(/^duplication:report/) ? DONE : GAP, ''],
+  ['📊 Code-health metrics', 'CodeHealth roll-up + dashboard', exists(path.join(HISTORY_DIR, 'codehealth-stamp.json')) ? DONE : GAP, ''],
+
+  ['⛓️ Enforcement gates (measured → enforced)', 'Circular-imports gate', ciHas(/madge|check-circular/i) ? DONE : GAP, 'madge — measured by code-health; not yet a CI gate'],
+  ['⛓️ Enforcement gates (measured → enforced)', 'Cognitive-complexity gate', /sonarjs.*cognitive|cognitive-complexity/i.test(eslintTxt) ? DONE : GAP, 'sonarjs/cognitive-complexity ≤ 15'],
+  ['⛓️ Enforcement gates (measured → enforced)', 'Cyclomatic-complexity rule', /["']complexity["']\s*:/.test(eslintTxt) ? DONE : GAP, "eslint `complexity` rule"],
+  ['⛓️ Enforcement gates (measured → enforced)', 'Doc-coverage gate', ciHas(/check-doc-coverage|docs:check/i) ? DONE : GAP, '`check-doc-coverage --gate` in CI'],
+
+  ['📚 Documentation', 'TSDoc coverage measured', npmScript(/doc/) || exists(path.join(HISTORY_DIR, 'codehealth-stamp.json')) ? DONE : PARTIAL, '/code-readability'],
+  ['📚 Documentation', 'API reference published', wikiStatus('Reference-Home'), 'Reference-Home/Components/Hooks/Lib/Types'],
+  ['📚 Documentation', 'Page-Anatomy (screen flows)', wikiStatus('Page-Anatomy'), 'Mermaid sequence diagrams'],
+  ['📚 Documentation', 'Team pages (onboarding)', wikiStatus('Getting-Started'), 'Getting-Started + Skill-Inventory'],
+  ['📚 Documentation', 'DB schema page', usesDrizzle ? (wikiStatus('Reference-Database-Schema')) : NA, usesDrizzle ? 'gen-schema-page' : 'N/A — no Drizzle ORM'],
+
+  ['🤖 Steward automation', 'Weekly sweep', /quality-steward[\s\S]*cron:/.test(ci) ? DONE : GAP, 'scheduled CodeHealth + review'],
+  ['🤖 Steward automation', 'Per-PR review', /quality-steward[\s\S]*pull_request/.test(ci) ? DONE : GAP, 'differential review on PRs'],
+  ['🤖 Steward automation', 'Shared wiki-publish substrate', exists('.claude/skills/wiki-publish') ? DONE : GAP, 'stamp + push'],
+];
+
+// ── Render ──
+const groups = [...new Set(CAPS.map((c) => c[0]))];
+const rows = ['| Capability | Status | Notes |', '|---|:--:|---|'];
+for (const g of groups) {
+  rows.push(`| **${g}** | | |`);
+  for (const [, name, status, detail] of CAPS.filter((c) => c[0] === g)) {
+    rows.push(`| ${name} | ${ICON[status]} | ${detail} |`);
+  }
+}
+const matrix = rows.join('\n');
+
+const counts = CAPS.reduce((a, [, , s]) => { a[s] = (a[s] || 0) + 1; return a; }, {});
+const applicable = CAPS.filter((c) => c[2] !== NA && c[2] !== MANUAL).length;
+const done = counts[DONE] || 0;
+const gaps = CAPS.filter((c) => c[2] === GAP);
+const summary = `**${done} / ${applicable}** auto-detected capabilities enabled · **${gaps.length} gaps** · ${counts[manualOr('manual')] || 0} need a manual/wiki check`;
+
+console.log(`\nQuality coverage — ${done}/${applicable} enabled, ${gaps.length} gaps (${today()})`);
+for (const g of groups) {
+  console.log(`  ${g}`);
+  for (const [, name, status, detail] of CAPS.filter((c) => c[0] === g)) {
+    console.log(`    ${ICON[status]} ${name}${detail ? `  — ${detail}` : ''}`);
+  }
+}
+if (gaps.length) {
+  console.log(`\n  GAPS to close:`);
+  for (const [, name, , detail] of gaps) console.log(`    ❌ ${name}${detail ? ` — ${detail}` : ''}`);
+}
+
+function manualOr(x) { return x; }
+
+const facts = {
+  matrix,
+  summary,
+  date: today(),
+  enabled: `${done} / ${applicable}`,
+  gaps: gaps.length ? gaps.map((g) => `\`${g[1]}\``).join(' · ') : 'none',
+};
+fs.mkdirSync(HISTORY_DIR, { recursive: true });
+fs.writeFileSync(path.join(HISTORY_DIR, 'quality-checklist.json'), JSON.stringify(facts, null, 2) + '\n');
+console.log(`\nwrote facts → ${path.join(HISTORY_DIR, 'quality-checklist.json')}`);
+
+if (stampTargets.length) {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const shared = path.resolve(here, '../../wiki-publish/scripts/stamp.mjs');
+  const factsFile = path.join(HISTORY_DIR, 'quality-checklist.json');
+  if (exists(shared)) {
+    execSync(`node "${shared}" "${factsFile}" ql ${stampTargets.map((t) => `"${t}"`).join(' ')}`, { stdio: 'inherit' });
+  } else {
+    console.error('  (/wiki-publish not installed — wrote facts JSON; stamp manually)');
+  }
+}

--- a/.github/workflows/quality-steward.yml
+++ b/.github/workflows/quality-steward.yml
@@ -101,7 +101,7 @@ jobs:
         # would let a compromised upstream execute inside it. Bump intentionally
         # after reviewing the upstream diff.
         env:
-          SKILLS_REF: 393fe22ffeccfa9dc1ea78ebca95ffdc907563f8 # bump to a reviewed commit  # pragma: allowlist secret (git SHA, not a credential)
+          SKILLS_REF: a19d7c7d90cdbdd7213402c34c61c61fcf3323c1 # bump to a reviewed commit  # pragma: allowlist secret (git SHA, not a credential)
         run: |
           git clone --filter=blob:none https://github.com/PrairieAster-Ai/claude-code-skills.git /tmp/ccs
           git -C /tmp/ccs checkout --quiet "$SKILLS_REF"

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "lint:api": "echo 'API linting integrated with deployment'",
     "type-check": "npm run type-check --workspace=@nearest-nice-weather/web",
     "codehealth:report": "node .claude/skills/code-health/scripts/run-all.mjs",
+    "quality:checklist": "node .claude/skills/code-health/scripts/quality-checklist.mjs",
     "mi:report": "node .claude/skills/code-health/scripts/maintainability-report.mjs",
     "complexity:report": "node .claude/skills/code-health/scripts/complexity-report.mjs",
     "hotspot:report": "node .claude/skills/code-health/scripts/hotspot-report.mjs",


### PR DESCRIPTION
Adds a **capability-coverage checklist** to the quality-steward so audits stop forgetting things.

## What
`quality-checklist.mjs` probes the repo (CI workflows, ESLint config, `package.json`, pre-commit, code-health history, installed skills, published wiki) for **every** quality capability the skills offer and flags each ✅ enabled / ⚠️ partial / ❌ available-but-off / ➖ n/a. Renders the **[Quality-Coverage](https://github.com/PrairieAster-Ai/nearest-nice-weather/wiki/Quality-Coverage)** wiki dashboard (stamped via `/wiki-publish`).

## What it caught (the 'forgotten' things)
NNW is **23/27** enabled, with **4 gaps** — all *measured but never enforced as CI gates*:
- ❌ Circular-imports gate (madge runs, not gating)
- ❌ Cognitive-complexity gate (no sonarjs)
- ❌ Cyclomatic-complexity ESLint rule
- ❌ Doc-coverage gate (`--gate` not in CI)

The dashboard documents how to close each (as **ratchets** at current levels, so nothing breaks).

## Wiring
- `npm run quality:checklist`; steward runs it in its weekly document step.
- Published to canonical `claude-code-skills` (`a19d7c7`); workflow `SKILLS_REF` bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)