### PR TITLE
docs(steward): document the steward-state branch in the agent

### DIFF
--- a/.claude/agents/quality-steward.md
+++ b/.claude/agents/quality-steward.md
@@ -62,13 +62,28 @@ State your detected mode in the first line of your final report.
 **The differential nature of the review skills matters.** `/code-review` and `/security-audit`
 operate on a **diff**, not a static tree — so a sweep against a clean working tree gives them
 nothing to chew on. For the **weekly sweep**, review the diff range you are given in the
-instruction. The shipped workflow computes `<last-sweep-sha>...HEAD` from a durable marker on a
-`steward-state` branch and persists the new HEAD after a successful run — CI runners are
-ephemeral, so that branch (not agent memory) is the source of truth. If no range is provided
-(e.g. an on-demand local run), fall back to your `project` memory's last-sweep SHA, else
-`git diff HEAD~20...HEAD` or the last 7 days (`git log --since='7 days ago'`) — keep the first
-sweep bounded so it completes within the turn budget. Trend deltas (step 1) remain repo-wide
-and are independent of this diff window.
+instruction. If no range is provided (e.g. an on-demand local run), fall back to your `project`
+memory's last-sweep SHA, else `git diff HEAD~20...HEAD` or the last 7 days
+(`git log --since='7 days ago'`) — keep the first sweep bounded so it completes within the turn
+budget. Trend deltas (step 1) remain repo-wide and are independent of this diff window.
+
+### The `steward-state` branch (durable state)
+
+CI runners are ephemeral, so agent memory does **not** survive between runs. A dedicated
+**`steward-state` branch** is the persistent source of truth, managed entirely by the shipped
+workflow (`.github/workflows/quality-steward.yml`), not by you. It holds:
+
+- **`last-sweep-sha`** — the HEAD the last successful sweep ran against. The workflow's "Resolve
+  sweep range" step diffs `<last-sweep-sha>...HEAD` into your instruction; "Persist sweep marker"
+  writes the new HEAD after a successful run.
+- **`code-health/*-history.tsv` + the stamp JSON** — the accumulated CodeHealth **trend**. The
+  workflow **restores** it into the working tree before you run, so `npm run codehealth:report`
+  *appends* a new row to real history (making the dashboard a trend line, not a fresh single-row
+  reading), then **persists** the updated trend back after the sweep.
+
+What this means for you: just run the metric command normally — the restore/persist is the
+workflow's job. **Never merge `steward-state` into the default branch, branch off it, or hand-edit
+it** — it's machine-owned state, not code. It self-bootstraps on the first run if absent.
 
 ## Playbook
 
@@ -132,4 +147,6 @@ notification carries this; locally it's your final message.
   at runtime; track `.claude/agents/` so the definition is checked out). See the package
   README for the workflow that does this.
 - Use `memory` to remember decisions across runs (e.g. a finding the maintainer dismissed —
-  don't re-raise it; the last-sweep SHA).
+  don't re-raise it). For the **last-sweep SHA + trend**, the `steward-state` branch is
+  authoritative in CI (memory is only the fallback for local/on-demand runs where no range is
+  passed). Don't write to `steward-state` yourself — the workflow does.

--- a/.github/workflows/quality-steward.yml
+++ b/.github/workflows/quality-steward.yml
@@ -101,7 +101,7 @@ jobs:
         # would let a compromised upstream execute inside it. Bump intentionally
         # after reviewing the upstream diff.
         env:
-          SKILLS_REF: efee0a608e10711359fb42180f2c7aba4b46fe21 # bump to a reviewed commit  # pragma: allowlist secret (git SHA, not a credential)
+          SKILLS_REF: ecff75fe3c5ee59c3273c483fa6f75c75852e594 # bump to a reviewed commit  # pragma: allowlist secret (git SHA, not a credential)
         run: |
           git clone --filter=blob:none https://github.com/PrairieAster-Ai/claude-code-skills.git /tmp/ccs
           git -C /tmp/ccs checkout --quiet "$SKILLS_REF"


### PR DESCRIPTION
Documents the `steward-state` branch in the quality-steward agent definition (your ask), and reconciles a stale canonical-vs-vendored divergence found along the way.

## What
- New **'The `steward-state` branch (durable state)'** section in the agent: it's the machine-owned source of truth holding the **last-sweep-sha** (anchors each weekly diff) **and** the persisted **code-health trend** (restored before / persisted after each sweep, so the dashboard is a trend line across ephemeral runners). Explicit: the agent must never merge, branch off, or hand-edit it.
- Reconciled the **memory guardrail** — `steward-state` is authoritative for the SHA+trend in CI; `memory` is the local/on-demand fallback.

## Why the canonical sync
CI `cp`s the agent definition from canonical at runtime, but canonical had drifted **behind** the vendored copy — missing the `/wiki-publish` note, the Quality-Coverage checklist step, and the dashboard-stamp step. Left as-is, a CI run would have regressed all of those. Synced canonical to the current version (`ecff75f`) and bumped `SKILLS_REF` so CI and local stay identical.

No app code; workflow YAML validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)