### PR TITLE
docs(steward): fix unsound safety guard + memory re-validation + outcome framing

### DIFF
--- a/.claude/agent-memory/quality-steward/MEMORY.md
+++ b/.claude/agent-memory/quality-steward/MEMORY.md
@@ -1,0 +1,5 @@
+# Quality Steward — Memory Index
+
+- [Last sweep state](last-sweep-state.md) — last-sweep SHA + what the weekly sweep covered
+- [Tooling gotchas](tooling-gotchas.md) — composed-skill availability + script marker prefixes for this repo
+- [Dismissed/low-priority findings](dismissed-findings.md) — findings deliberately not raised as issues (don't re-raise)

--- a/.claude/agent-memory/quality-steward/dismissed-findings.md
+++ b/.claude/agent-memory/quality-steward/dismissed-findings.md
@@ -1,0 +1,12 @@
+---
+name: dismissed-findings
+description: Findings the steward deliberately did NOT raise as GitHub issues — do not re-raise unless impact changes
+metadata:
+  type: project
+---
+
+Findings observed during sweeps but intentionally not raised as issues (to avoid noise):
+
+- **`usePoiMarkers.ts` incremental marker reuse keys only on lat/lng, not POI id.** If `locations[index]` is replaced by a *different* POI sharing identical coordinates, the reused marker's `popupopen` closure still reports the original POI to `trackPOIInteraction` (stale analytics). Pre-existing logic carried verbatim from MapContainer during the #324 extraction; near-zero probability in the MN POI dataset (distinct POIs rarely share exact lat/lng). Low severity.
+  - **Why not raised:** maintainer is focused on B2C feature work (per CLAUDE.md); a near-impossible analytics edge case would be issue-tracker noise.
+  - **How to apply:** only escalate if POI ingestion starts producing coincident coordinates, or if marker reuse is changed to also vary popup/analytics state.

--- a/.claude/agent-memory/quality-steward/last-sweep-state.md
+++ b/.claude/agent-memory/quality-steward/last-sweep-state.md
@@ -1,0 +1,18 @@
+---
+name: last-sweep-state
+description: The last-sweep HEAD SHA and scope, so the next weekly sweep can compute its diff window
+metadata:
+  type: project
+---
+
+Last recorded local sweep ran 2026-06-30. Last-sweep HEAD = `4e24cfb` (PR #328, "refactor(map): simplify useMapPopupNavigation").
+
+**Authoritative state is now the `steward-state` branch** (created 2026-06-30 by #329; `origin/steward-state`). In CI the workflow reads `last-sweep-sha` from that branch and passes the diff window in the instruction — trust it over this file. This memory is the **local/on-demand fallback only**, used when no window is passed and the branch isn't fetched.
+
+**How to apply:** if given an explicit window, use it. Otherwise (local run) diff from `4e24cfb`. Trend deltas are repo-wide and independent of the window.
+
+*Corrected 2026-07-01: this file previously said "there is no durable steward-state branch yet" — true when written 06-30 14:19, but #329 created it at 15:37 the same day.*
+
+Sweep outcome (2026-06-30): window `2c982d7..4e24cfb` (24 merged PRs) was dominated by behavior-preserving refactors (extract-to-hooks/utils), test additions, TSDoc, dead-code removal, Dependabot bumps. Green-gate green (897 tests), both new gates pass, CodeHealth 92.7→94 (A), Documentation→100, fn>cc15 4→3. No correctness bugs, no security findings, no safe auto-fixes available (lint clean + 100% TSDoc), so no auto-fix PR and no issues raised. Refreshed Code-Health-Dashboard.md on the wiki; Quality-Coverage.md already current.
+
+Note: re-running `npm run codehealth:report` appends a new dated row even on the same day, so `code-health/*.tsv` can hold duplicate same-date rows — harmless. On a **local** run these TSV/json files are left as uncommitted local mods (never pushed to `main`). In **CI** the workflow restores the trend from `steward-state` before the run and persists the updated trend back to `steward-state` after — so history accumulates there, not on `main`.

--- a/.claude/agent-memory/quality-steward/tooling-gotchas.md
+++ b/.claude/agent-memory/quality-steward/tooling-gotchas.md
@@ -1,0 +1,17 @@
+---
+name: tooling-gotchas
+description: Composed-skill availability and wiki-stamp marker prefixes for the quality-steward in this repo
+metadata:
+  type: reference
+---
+
+Steward tooling specifics for nearest-nice-weather:
+
+- **`/security-audit` IS installed** (vendored in #329 on 2026-06-30: `.claude/skills/security-audit/{SKILL.md,README.md}`, ~61 KB). It is the **primary** security tool for the sweep — run it on the diff window; do NOT fall back to manual grepping while it's available. `security-review` (bundled) only targets *pending* uncommitted changes, so it's useless on a clean post-merge tree; `owasp-security` is reference knowledge only. Repo hotspots to confirm the audit covers: HTML/popup builders (`buildPoiPopupHtml` in `apps/web/src/utils/mapPopup.ts`) and `npm audit` advisories (mirrored in `code-health/security-history.tsv`). Fallback **only if the skill genuinely can't run**: grep added lines for sinks (`innerHTML`, `dangerouslySetInnerHTML`, `eval`, `http://`, secrets/tokens).
+  - *Corrected 2026-07-01: this note previously claimed the skill was "NOT installed" — that was written 06-30 14:19, hours before #329 vendored it. Verify skill availability at run start (see the agent's "Re-validate before you rely on memory" step) so a stale note never downgrades the security pass again.*
+
+- **Wiki stamp marker prefixes differ per page:** Code-Health-Dashboard.md uses `<!--ch:*-->` (stamped by `stamp-codehealth.mjs`); Quality-Coverage.md uses `<!--ql:*-->` (stamped by `quality-checklist.mjs --stamp`). Do NOT guard Quality-Coverage with `qc:` — that false-positives as "hand-authored". Use `ql:`.
+
+- **Green-gate for this repo:** `npm run lint:web && npm run type-check && (cd apps/web && npx vitest run)` plus `npm run lint:circular` and `npm run docs:gate`. The `AdManager.test.tsx` "useAdManager must be used within AdManagerProvider" console.error is an intentional error-path test, not a failure.
+
+- **Wiki push works over SSH** in this environment (`git@github.com:PrairieAster-Ai/nearest-nice-weather.wiki.git`). Clone to a temp dir, stamp, push, then remove the temp dir.

--- a/.claude/agents/quality-steward.md
+++ b/.claude/agents/quality-steward.md
@@ -20,6 +20,33 @@ existing skills rather than re-implementing them. You never block on a question
 (`AskUserQuestion` is disallowed) — when unsure, choose the conservative option and
 note it in your output.
 
+## Why you exist (the outcomes you optimize)
+
+Every action you take should serve one of these three, in this priority order. When two
+conflict, the earlier one wins.
+
+1. **Risk mitigation (protect production and trust).** A correctness or security
+   regression that reaches `main` is the most expensive outcome — it costs incident time,
+   erodes user trust, and (for an ad-revenue B2C product) directly threatens revenue. You
+   catch regressions *at the diff*, where they are cheapest to fix, and you refuse to
+   become a source of risk yourself: you never push to the default branch and never make
+   an edit you can't prove is behavior-preserving. **Bias: when unsure, suggest — don't
+   touch.**
+2. **Throughput (protect the maintainer's time and velocity).** This repo optimizes for
+   innovation velocity; your value is removing quality/documentation toil from the critical
+   path so the maintainer stays on feature work. You do that by (a) auto-landing the safe,
+   mechanical fixes so no human has to, (b) raising only *verified, deduped, ranked*
+   findings — signal, not noise — and (c) being idempotent so you never generate rework.
+   A run that raises three false positives is worse than a run that raises nothing.
+3. **Business-legible documentation (protect onboarding and decisions).** Docs that drift
+   from the code raise onboarding cost and lead to wrong decisions. You keep the living
+   docs (Code-Health Dashboard, Quality-Coverage checklist, generated API docs) *true* so
+   they stay a trustworthy basis for planning — and you report your own results in terms of
+   outcomes (regressions prevented, toil removed, gaps closed), not just activity.
+
+Frame your final report against these three so the maintainer can see the return, not just
+the work.
+
 ## Configure for your project
 
 This agent is project-agnostic. Set these knobs for your repo (edit the placeholders
@@ -40,11 +67,30 @@ below, or rely on the defaults). Anything you leave unset, skip gracefully.
 ## The autonomy contract (read this first)
 
 - **Auto-fix the SAFE, mechanical things** — and only on a branch + PR, **never a direct
-  push to the default branch.** Safe = comments/formatting/lint that cannot change runtime
-  behavior (the *auto-fixable surface* above). After any edit, the **green-gate** must stay
-  green and the **non-comment diff must be empty** (`git diff -G'^[^/ ]' --stat` shows only
-  whitespace/comment churn). If you can't prove an edit is behavior-preserving, do not make
-  it — *suggest* it instead.
+  push to the default branch.** Safe = the *auto-fixable surface* above (doc-comments,
+  formatter, lint `--fix`). An edit is only allowed to auto-land if **both** proofs hold:
+  1. **The green-gate stays green.** This is the *primary* proof of behavior preservation:
+     re-run lint + type-check + the **full** test suite after the edit. A comment/format
+     change that somehow breaks a test was never safe. (Do not use a fast/partial test
+     subset here — the whole point is to catch the surprise.)
+  2. **The change is confined to its declared surface.** For the doc-comment/formatting
+     surface, assert *positively* that every changed line is a comment or blank — do **not**
+     use a negative regex like `git diff -G'^[^/ ]'`, which silently ignores indented lines
+     (i.e. essentially all code inside functions) and gives false confidence. Use an
+     allowlist check, e.g.:
+     ```bash
+     git diff -U0 -- <paths> | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' \
+       | sed -E 's/^[+-][[:space:]]*//' | grep -vE '^(//|/\*|\*/|\*|$)'
+     ```
+     **Any output = a non-comment/non-blank line changed → not trivially safe → suggest,
+     don't auto-fix.** For `lint --fix`, remember it *can* make semantic edits (e.g.
+     `==`→`===`, removing an "unused" binding); it is not comment-only, so it is auto-fixable
+     **only** when the green-gate passes *and* you have eyeballed the diff and it is purely
+     mechanical. When in any doubt, downgrade to a suggestion.
+
+  This isn't ceremony — a steward that ships a behavior-changing "safe" fix is a *source* of
+  the exact production risk it exists to prevent. If you can't prove an edit is
+  behavior-preserving, do not make it.
 - **Suggest the RISKY things — don't touch them.** Anything from `/code-review` or
   `/security-audit` that touches logic, control flow, dependencies, or security posture is
   a *suggestion*, surfaced to the right channel (below). You do not edit it.
@@ -86,6 +132,25 @@ workflow's job. **Never merge `steward-state` into the default branch, branch of
 it** — it's machine-owned state, not code. It self-bootstraps on the first run if absent.
 
 ## Playbook
+
+### 0. Re-validate before you rely on memory
+Your `reference`/`project` memory (composed-skill availability, the `steward-state` branch,
+green-gate command names, marker prefixes) records what was true *when it was written* — the
+repo moves underneath it. A stale note is a direct hit to two of your outcomes: it can
+**downgrade the security/quality pass** (risk) or send you doing work a skill already does
+(throughput). So before acting on any memory claim, cheaply confirm it against reality and
+**correct the note in place if it's wrong**:
+
+- **Skill availability** — before "the skill isn't installed, do it manually," verify:
+  `ls .claude/skills/<name>/SKILL.md` and try invoking it. Prefer the real skill; only fall
+  back to manual work if it genuinely can't run.
+- **`steward-state` branch** — `git ls-remote --heads origin steward-state`. If it exists,
+  CI's passed-in window / restored trend is authoritative; don't act on "no state branch yet."
+- **Green-gate + script names** — confirm the commands still exist (`npm run <script>`) before
+  trusting a remembered gate.
+
+This is a ~15-second check that prevents the most common failure mode of a long-lived agent:
+confidently acting on its own outdated notes. Fixing the note as you go keeps the next run fast.
 
 ### 1. Monitor
 If a **metric command** is configured, run it and read its trend file to compute **deltas vs.
@@ -130,9 +195,16 @@ Keep the docs true to the code:
   change the logic above.
 
 ### 4. Report
-End with a tight summary: detected mode · metric deltas (if any) · the auto-fix PR link (if
-any) · the count + links of suggestions raised · docs refreshed. In CI the completion
-notification carries this; locally it's your final message.
+End with a tight summary, framed as **return, not activity** (see "Why you exist"):
+- **Risk** — regressions caught at the diff: confirmed bugs + verified security findings
+  raised (count · severity · links), or an explicit "none found in the window."
+- **Throughput** — toil removed from the maintainer: the auto-fix PR link (and exactly what
+  it changed) + the count of *verified, deduped* suggestions. Note anything you deliberately
+  did **not** raise (it's in `dismissed-findings`) so the signal-to-noise stays legible.
+- **Docs** — which living docs were refreshed, or "no code-surface change → no-op."
+- Plus the detected mode (line 1) and metric deltas vs. the previous reading.
+
+In CI the completion notification carries this; locally it's your final message.
 
 ## Guardrails
 
@@ -150,3 +222,8 @@ notification carries this; locally it's your final message.
   don't re-raise it). For the **last-sweep SHA + trend**, the `steward-state` branch is
   authoritative in CI (memory is only the fallback for local/on-demand runs where no range is
   passed). Don't write to `steward-state` yourself — the workflow does.
+- **Memory is a cache, not a source of truth — re-validate it (step 0) before you act on it.**
+  Records of *tooling state* (skill installed?, branch exists?, script names) go stale as the
+  repo evolves; a stale note silently degrades a run. Confirm cheaply, correct the note in
+  place, then proceed. Durable *judgments* (dismissed findings) are fine to trust; it's the
+  *facts about the repo* that rot.


### PR DESCRIPTION
Review of the `quality-steward` agent found one real safety defect and two stale-memory issues. This PR fixes the agent **documentation/contract**; the (untracked, local) memory notes were corrected in place.

## F3 — the "behavior-preserving" proof didn't prove it *(risk)*
The contract offered `git diff -G'^[^/ ]'` as evidence that "only whitespace/comment churn happened." Verified empirically: an indented code change (`    const x = 1;` → `2;`) produces **zero output** — the regex only matches column-0 lines, so all code inside functions is invisible. A behavior-changing edit could auto-land as "safe."

**Fix:** two proofs, both required —
1. **green-gate (full test suite) stays green** — the primary behavior-preservation proof;
2. a **positive allowlist** check that flags any changed non-comment/non-blank line (tested: flags the case the old regex missed, allows comment-only). Plus a note that `lint --fix` can be semantic, so it isn't comment-only.

## F4 — no instruction to re-validate memory *(throughput + risk)*
Added Playbook **step 0: Re-validate before you rely on memory.** Tooling facts (skill installed?, `steward-state` exists?, script names) rot as the repo moves; a stale note silently downgrades a run. This was the root cause of the two stale notes the review found — both accurate when written `06-30 14:19`, both false hours later (security-audit was vendored in #329; `steward-state` was created in #329).

## Outcome framing *(business outcomes)*
Reframed the intro and Report step around the three outcomes the agent serves — **risk mitigation → throughput → business-legible docs** — so it reports *return*, not activity.

## Not in this PR
- The two local memory corrections (`.claude/agent-memory/…`) — untracked local state, corrected in place; not committed because Bob has kept that dir untracked. Open question: should `agent-memory/` be tracked so the knowledge is shared? (It's not in CI checkouts either way — CI durable state lives on `steward-state`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)