### PR TITLE
chore(onboarding): remove dead USE_MOCK_WEATHER / USE_SEED_DATA toggles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,5 +69,4 @@ RATE_LIMIT_MAX_REQUESTS="1000"
 #   1. DATABASE_URL → create a free Neon project (https://console.neon.tech), use its
 #                     dev-branch URL, then seed it:  node scripts/seed-minnesota-parks.js
 #   2. OPENWEATHER_API_KEY → free key at https://openweathermap.org/api
-#                     (or set USE_MOCK_WEATHER=true to develop without a weather key)
 # Verify any time:  npm run doctor -- --profile contributor

--- a/dev-onboarding.config.json
+++ b/dev-onboarding.config.json
@@ -14,10 +14,10 @@
   ],
   "secrets": {
     "DATABASE_URL": { "profiles": ["team", "contributor"], "shape": "^postgres(ql)?://", "help": "Neon Postgres dev-branch URL — team: internal project; contributor: your own free Neon account (https://console.neon.tech)" },
-    "OPENWEATHER_API_KEY": { "profiles": ["team", "contributor"], "shape": "^[A-Za-z0-9]{20,}$", "mockToggle": "USE_MOCK_WEATHER", "help": "free OpenWeather key (https://openweathermap.org/api)" }
+    "OPENWEATHER_API_KEY": { "profiles": ["team", "contributor"], "shape": "^[A-Za-z0-9]{20,}$", "help": "free OpenWeather key (https://openweathermap.org/api)" }
   },
   "profiles": {
     "team": { "desc": "internal access to the Neon project + OpenWeather + Vercel" },
-    "contributor": { "desc": "own free-tier Neon + OpenWeather; no internal access", "seedCommand": "node scripts/seed-minnesota-parks.js", "mockEnv": ["USE_SEED_DATA=true"] }
+    "contributor": { "desc": "own free-tier Neon + OpenWeather; no internal access", "seedCommand": "node scripts/seed-minnesota-parks.js" }
   }
 }


### PR DESCRIPTION
Follow-up from the quality-steward on-demand sweep (`e0cf9ba..HEAD`). The steward found both onboarding toggles are **advertised but wired to no runtime code** (grep-verified: zero readers).

- **`USE_MOCK_WEATHER`** — `doctor.mjs` tells a keyless contributor "set `USE_MOCK_WEATHER=true` to skip," but `weatherService.js` already falls back to mock weather **unconditionally** when the key is absent. So the toggle was unread *and* redundant, and the fallback is silent — crosswise to CLAUDE.md's data-integrity rule. Removed the `mockToggle` declaration + the `.env.example` mention.
- **`USE_SEED_DATA`** — `bootstrap.mjs` wrote it into the contributor `.env`, but seeding is done by `seedCommand` (`seed-minnesota-parks.js`). Removed the `mockEnv` declaration.

## Scope: 2 files, not 5
The toggles were **config-driven** — declared only in `dev-onboarding.config.json` + `.env.example`. The generic skill scripts (`doctor`/`bootstrap`) reference them only *if* the config declares them (`spec.mockToggle ? … : ''`, iterating `prof.mockEnv`), so they stop surfacing automatically. `scaffold.mjs`'s mentions are generic template examples for scaffolding *other* projects. Leaving the vendored skill scripts untouched keeps them in sync with canonical.

## Verified
- `dev-onboarding.config.json` still valid JSON; `npm run doctor -- --profile contributor` runs clean with no dead-toggle prompt.

## Deferred (separate decision)
The silent unconditional mock-weather fallback in `weatherService.js` itself is **unchanged** — you chose docs-only cleanup. Wiring the fallback to an explicit opt-in (to fully satisfy the data-integrity rule) remains available as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)