### PR TITLE
fix(validation): probe live POI endpoint, not retired /api/weather-locations

### DIFF
--- a/scripts/environment-validation.sh
+++ b/scripts/environment-validation.sh
@@ -189,8 +189,9 @@ main() {
     # Test 1: Health check - Most basic API test
     test_api_endpoint "/api/health" "Health Check" "success"
 
-    # Test 2: Weather locations - Database connectivity
-    test_api_endpoint "/api/weather-locations?limit=3" "Weather Locations" "data"
+    # Test 2: POI locations with weather - Database connectivity + weather integration
+    # (Replaces the retired /api/weather-locations endpoint from the POI-centric refactor.)
+    test_api_endpoint "/api/poi-locations-with-weather?limit=3" "POI Locations with Weather" "data"
 
     # Test 3: Feedback system - Database write operations (skip for production)
     if [[ "$ENVIRONMENT" != "production" && "$ENVIRONMENT" != "prod" ]]; then


### PR DESCRIPTION
## Problem
`environment-validation.sh` (the SOP validation script) tested `/api/weather-locations`, an endpoint **removed in the POI-centric refactor**. The request fell through to the SPA and returned `index.html`, so the script reported a false `❌ Missing expected field: data` on every run — including today's post-deploy preview validation.

## Fix
Point the test at the live `/api/poi-locations-with-weather` endpoint (same `data` contract, and it also exercises the weather integration).

**Verified:** `./scripts/environment-validation.sh preview` → 3/3 API, 4/4 frontend, **OVERALL HEALTHY**.

## Heads-up: broader rot (not in this PR)
The retired `/api/weather-locations` is still referenced by ~7 other **active** scripts that would similarly false-fail or misbehave against it:
- `scripts/automated-parity-testing.sh` (localhost↔preview parity compare)
- `scripts/utilities/environment-health-check.sh` (referenced in CLAUDE.md's productivity checks)
- `scripts/sync-localhost-to-preview.sh`
- `scripts/compare-database-schemas.sh`
- `scripts/utilities/debug-preview-standalone.js`
- `scripts/development/claude-intelligence-config.js`
- `scripts/unified-dev-start.sh` (`start:legacy`)

Scoped this PR to the requested SOP script; happy to do a follow-up sweep for the rest (some need more than a path swap — parity/sync scripts extract `.count`/`.data[0]` and compare, so they need reviewing individually).

🤖 Generated with [Claude Code](https://claude.com/claude-code)