### PR TITLE
fix(scripts): sweep retired /api/weather-locations across 7 active scripts

### DIFF
--- a/scripts/automated-parity-testing.sh
+++ b/scripts/automated-parity-testing.sh
@@ -113,14 +113,14 @@ compare_api_responses "/api/health" "Health endpoint comparison" ".status"
 # Test 2: POI locations count
 compare_api_responses "/api/poi-locations" "POI locations count" ".count"
 
-# Test 3: Weather locations count
-compare_api_responses "/api/weather-locations" "Weather locations count" ".count"
+# Test 3: POI locations count
+compare_api_responses "/api/poi-locations-with-weather" "POI locations count" ".count"
 
 # Test 4: POI data types (first record)
 compare_api_responses "/api/poi-locations?limit=1" "POI data types" ".data[0] | {name, lat: (.lat | type), lng: (.lng | type)}"
 
-# Test 5: Weather data types (first record)
-compare_api_responses "/api/weather-locations?limit=1" "Weather data types" ".data[0] | {name, lat: (.lat | type), lng: (.lng | type)}"
+# Test 5: POI data types (first record)
+compare_api_responses "/api/poi-locations-with-weather?limit=1" "POI data types" ".data[0] | {name, lat: (.lat | type), lng: (.lng | type)}"
 
 echo
 echo -e "${BLUE}🗺️  Geographic Data Consistency Tests${NC}"
@@ -163,7 +163,7 @@ echo
 # Test 8: Both APIs return successful responses
 run_test "POI locations API success" "curl -s '$LOCALHOST_URL/api/poi-locations' | jq -e '.success == true' && curl -s '$PREVIEW_URL/api/poi-locations' | jq -e '.success == true'"
 
-run_test "Weather locations API success" "curl -s '$LOCALHOST_URL/api/weather-locations' | jq -e '.success == true' && curl -s '$PREVIEW_URL/api/weather-locations' | jq -e '.success == true'"
+run_test "POI locations API success" "curl -s '$LOCALHOST_URL/api/poi-locations-with-weather' | jq -e '.success == true' && curl -s '$PREVIEW_URL/api/poi-locations-with-weather' | jq -e '.success == true'"
 
 # Test 9: Response time consistency (should be similar order of magnitude)
 echo -n "   Response time consistency... "

--- a/scripts/compare-database-schemas.sh
+++ b/scripts/compare-database-schemas.sh
@@ -39,7 +39,7 @@ get_table_info() {
     curl -s "$api_url/api/poi-locations?limit=1" | jq '.data[0] // {}' > "${temp_file}_poi.json"
 
     # Get weather locations structure
-    curl -s "$api_url/api/weather-locations?limit=1" | jq '.data[0] // {}' > "${temp_file}_weather.json"
+    curl -s "$api_url/api/poi-locations-with-weather?limit=1" | jq '.data[0] // {}' > "${temp_file}_weather.json"
 
     # Get health check (includes environment info)
     curl -s "$api_url/api/health" | jq '.' > "${temp_file}_health.json" 2>/dev/null || echo '{}' > "${temp_file}_health.json"

--- a/scripts/development/claude-intelligence-config.js
+++ b/scripts/development/claude-intelligence-config.js
@@ -110,7 +110,7 @@ module.exports = {
   // Nearest Nice Weather specific monitoring
   weatherPlatformConfig: {
     apiEndpoints: [
-      '/api/weather-locations',
+      '/api/poi-locations-with-weather',
       '/api/feedback',
       '/api/health'
     ],

--- a/scripts/sync-localhost-to-preview.sh
+++ b/scripts/sync-localhost-to-preview.sh
@@ -37,7 +37,7 @@ if ! curl -s "http://localhost:4000/api/poi-locations" | jq '.data' > "$TEMP_DIR
 fi
 
 echo "   - Fetching weather locations..."
-if ! curl -s "http://localhost:4000/api/weather-locations" | jq '.data' > "$TEMP_DIR/localhost-weather-data.json"; then
+if ! curl -s "http://localhost:4000/api/poi-locations-with-weather" | jq '.data' > "$TEMP_DIR/localhost-weather-data.json"; then
     echo "❌ Failed to fetch localhost weather data"
     exit 1
 fi
@@ -120,7 +120,7 @@ fi
 
 # Check record counts
 PREVIEW_POI_COUNT=$(curl -s "https://p.nearestniceweather.com/api/poi-locations" | jq '.count')
-PREVIEW_WEATHER_COUNT=$(curl -s "https://p.nearestniceweather.com/api/weather-locations" | jq '.count')
+PREVIEW_WEATHER_COUNT=$(curl -s "https://p.nearestniceweather.com/api/poi-locations-with-weather" | jq '.count')
 
 echo "   Record counts:"
 echo "   - POI locations: localhost=$POI_COUNT, preview=$PREVIEW_POI_COUNT"

--- a/scripts/unified-dev-start.sh
+++ b/scripts/unified-dev-start.sh
@@ -311,7 +311,7 @@ else
 fi
 
 # Test API data endpoints (deeper validation)
-if curl -s "http://localhost:$API_PORT/api/weather-locations?limit=1" | grep -q "success"; then
+if curl -s "http://localhost:$API_PORT/api/poi-locations-with-weather?limit=1" | grep -q "success"; then
     success "API Data Endpoints: PASSED"
 else
     warning "API Data Endpoints: FAILED - Database connectivity issues"
@@ -353,7 +353,7 @@ if [[ -n $BROWSERTOOLS_PID && "$FRONTEND_CHECK_RESULT" == "PASSED" ]]; then
 fi
 
 # Test API proxy through frontend (critical integration test)
-if curl -s "http://localhost:$FRONTEND_PORT/api/weather-locations?limit=1" | grep -q "success"; then
+if curl -s "http://localhost:$FRONTEND_PORT/api/poi-locations-with-weather?limit=1" | grep -q "success"; then
     success "API Proxy Integration: PASSED"
 else
     warning "API Proxy Integration: FAILED - Frontend/API connection broken"

--- a/scripts/utilities/debug-preview-standalone.js
+++ b/scripts/utilities/debug-preview-standalone.js
@@ -176,7 +176,7 @@ async function debugPreviewEnvironment() {
     const endpoints = [
       '/api/health',
       '/api/poi-locations-with-weather?limit=5',
-      '/api/weather-locations?limit=5',
+      '/api/poi-locations-with-weather?limit=5',
       '/api/poi-locations?limit=5'
     ]
 

--- a/scripts/utilities/environment-health-check.sh
+++ b/scripts/utilities/environment-health-check.sh
@@ -98,7 +98,7 @@ echo "=============================="
 # Check core services
 check_service "Frontend (Vite)" "http://localhost:3001/" 20
 check_service "API Server" "http://localhost:4000/api/health" 20
-check_service "API Proxy" "http://localhost:3001/api/weather-locations?limit=1" 15
+check_service "API Proxy" "http://localhost:3001/api/poi-locations-with-weather?limit=1" 15
 
 echo ""
 echo "🗄️ DATABASE SERVICES"


### PR DESCRIPTION
Follow-up to #338. The `/api/weather-locations` endpoint (removed in the POI-centric refactor) was still referenced by **7 active scripts** — all would false-fail or misbehave against a route that now falls through to SPA HTML.

Swapped each to the live `/api/poi-locations-with-weather`, which returns the **same envelope** (`{success, data, count}`, `data[0]` has `name`/`lat`/`lng`) — so the `.count`/`.data`/`.data[0]`/`.success` extractions all keep working.

| Script | Usage |
|---|---|
| `automated-parity-testing.sh` | localhost↔preview count/data-type/success parity (+ labels refreshed) |
| `utilities/environment-health-check.sh` | API-proxy health probe |
| `sync-localhost-to-preview.sh` | `.data` / `.count` extraction |
| `compare-database-schemas.sh` | `.data[0]` schema compare |
| `utilities/debug-preview-standalone.js` | endpoint probe list |
| `development/claude-intelligence-config.js` | monitored-endpoint list |
| `unified-dev-start.sh` | `start:legacy` health checks |

**Verified:** `bash -n` / `node --check` pass on all 7; the `.success`/`.count`/`.data[0]` extractions confirmed against the live preview endpoint (`.count = 200`, `data[0]` shape correct). Archived scripts under `scripts/archived/` left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)