### PR TITLE
fix(validation): correct hardcoded "Preview" label in overall status

### DIFF
--- a/scripts/environment-validation.sh
+++ b/scripts/environment-validation.sh
@@ -320,7 +320,7 @@ main() {
 
     # Determine overall status
     if [[ $api_score -ge 80 && $frontend_score -ge 80 ]]; then
-        success "OVERALL STATUS: HEALTHY - Preview environment fully operational"
+        success "OVERALL STATUS: HEALTHY - $ENV_NAME fully operational"
         exit 0
     elif [[ $api_score -ge 80 && $frontend_score -lt 80 ]]; then
         error "OVERALL STATUS: FRONTEND ISSUES - API working but frontend problems detected"


### PR DESCRIPTION
Follow-up from the production deploy. `environment-validation.sh` printed `OVERALL STATUS: HEALTHY - Preview environment fully operational` regardless of the target — so a production run mislabeled itself as "Preview" in output and the log file.

Fix: use the already-computed `$ENV_NAME` (Localhost Development / Preview Environment / Production Environment / Custom Environment).

**Verified:** `./scripts/environment-validation.sh production` → `HEALTHY - Production Environment fully operational`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)